### PR TITLE
Remove old antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,8 +1,0 @@
-name: rke2
-title: RKE2
-version: main
-display_version: 'v1.31'
-start_page: en:introduction.adoc
-nav:
-- modules/en/nav.adoc
-- modules/zh/nav.adoc


### PR DESCRIPTION
- Remove old antora.yml
- When running `make remote` I am getting the following: 

  <img width="1755" alt="Screenshot 2024-09-11 at 12 11 27 PM" src="https://github.com/user-attachments/assets/79f4ba4d-7dd6-44e8-b4b6-fb8df4d7105c">
