### PR TITLE
Add springio/antora-xref-extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@antora/lunr-extension": "^1.0.0-alpha.8",
+        "@springio/antora-xref-extension": "^1.0.0-alpha.4",
         "http-server": "^14.1.1",
         "nodejieba": "^3.4.2"
       },
@@ -379,6 +380,14 @@
       "resolved": "https://registry.npmjs.org/@sntke/antora-mermaid-extension/-/antora-mermaid-extension-0.0.6.tgz",
       "integrity": "sha512-c4L+JsJYQYq/R73h5yRdBBR1jVkVdhIm6yhRy1Y009IpvvYAQor3TIxwaFXnPNR2NyfSlXUpXHelkEHddmJMOw==",
       "dev": true
+    },
+    "node_modules/@springio/antora-xref-extension": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@springio/antora-xref-extension/-/antora-xref-extension-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-ybIqQaNgK2pjAkOAd/A+IXK5AmxDZcKfpsp528UXIG2N3L4KFwvwljhANHktS0HHiN5QMZp0PuD0WZsClpenhQ==",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@springio/antora-xref-extension": "^1.0.0-alpha.4",
     "http-server": "^14.1.1",
     "nodejieba": "^3.4.2"
   }

--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -30,3 +30,4 @@ antora:
     - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
       attributefile: ./product-docs-common/global-attributes.yml
       enabled: true
+    - require: '@springio/antora-xref-extension'

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -33,3 +33,4 @@ antora:
   - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
     attributefile: ./product-docs-common/global-attributes.yml
     enabled: true
+  - require: '@springio/antora-xref-extension'


### PR DESCRIPTION
Adds the [spring-io/antora-xref-extension](https://github.com/spring-io/antora-xref-extension) extension as Antora's built-in validation doesn't support xrefs with fragments (i.e. linking to the header of another file). 

Note, CI for this PR itself runs with the extension enabled and broken links of this type are considered `ERROR` level by the extension. If there are any such broken links, CI won't pass until the links are fixed.

Depends on https://github.com/rancher/rke2-product-docs/issues/20.

