### PR TITLE
Include Prime information when installing RKE2 in airgap

### DIFF
--- a/versions/latest/modules/en/pages/install/airgap.adoc
+++ b/versions/latest/modules/en/pages/install/airgap.adoc
@@ -3,7 +3,7 @@
 :revdate: 2025-08-06
 :page-revdate: {revdate}
 
-{product-name} can be installed in an air-gapped environment with two different methods. You can either deploy via the `rke2-airgap-images` tarball artifact or by using a private registry.
+To install {product-name} can be installed in an air-gapped environment, you must first load the images into the air-gapped environment and then install RKE2.
 
 [IMPORTANT]
 ====
@@ -31,7 +31,12 @@ ip addr add 203.0.113.254/31 dev dummy0
 ip route add default via 203.0.113.255 dev dummy0 metric 1000
 ----
 
-== Tarball Method
+== 1. Load Images
+
+There are two different methods to load the images. Each image loading method has different requirements and is suited for different air-gapped scenarios. Choose the method that best fits your infrastructure and security requirements.
+
+
+=== Tarball Method
 
 . Download the air-gap images tarballs from the https://scc.suse.com/rancher-docs/rancherprime/latest/en/reference-guide.html#prime-artifacts-url[Prime Artifacts URL] for the RKE2 version, CNI, and platform you are using.
  ** `rke2-images.linux-<ARCH>.tar.zst`, or `rke2-images-core.linux-<ARCH>.tar.gz`. This tarball contains the core container images required for RKE2 Prime to function. Zstandard offers better compression ratios and faster decompression speeds compared to gzip.
@@ -41,16 +46,18 @@ ip route add default via 203.0.113.255 dev dummy0 metric 1000
  *** If using your own CNI (`--cni=none`), download only the `rke2-images-core` archive.
  ** If enabling the vSphere CPI/CSI charts (`--cloud-provider-name=rancher-vsphere`), you must also download the `rke2-images-vsphere` archive.
 . Create a directory named `/rke2-artifacts` on the node and save the previously downloaded files there.
-. <<Install RKE2>>.
+. <<2. Install RKE2, Istall RKE2>>.
 
-== Private Registry Method
+
+=== Private Registry Method
 
 Private registry support honors all settings from the xref:install/containerd_registry_configuration.adoc[containerd registry configuration], including endpoint override, transport protocol (HTTP/HTTPS), authentication, certificate verification, and more.
 
 . Add all the required system images to your private registry. A list of images can be obtained from the `.txt` file corresponding to each tarball referenced above. Alternatively, you can `docker load` the airgap image tarballs, then tag and push the loaded images.
-. <<Install RKE2>> using the `system-default-registry` parameter, or use the xref:install/containerd_registry_configuration.adoc[containerd registry configuration] to use your registry as a mirror for docker.io.
+. <<2. Install RKE2, Install RKE2>> using the `system-default-registry` parameter, or use the xref:install/containerd_registry_configuration.adoc[containerd registry configuration] to use your registry as a mirror for docker.io.
 
-== Install RKE2
+
+== 2. Install RKE2
 
 The following options to install RKE2 should only be performed after completing either the <<Tarball Method>> or <<Private Registry Method>>.
 
@@ -102,6 +109,16 @@ curl -sfL https://get.rke2.io --output install.sh
 [,bash]
 ----
 INSTALL_RKE2_ARTIFACT_PATH=/rke2-artifacts sh install.sh
+----
+
+. If you are using the Rancher Prime registry, set the following values in `config.yaml`:
+.. Set `system-default-registry: registry.rancher.com`.
+.. If you are not using the default CNI, Canal, set `cni: <CNI>`.
++
+[,yaml]
+----
+system-default-registry: registry.rancher.com
+cni: <CNI>
 ----
 
 . Enable and run the service as outlined xref:install/quickstart.adoc[here].

--- a/versions/latest/modules/zh/pages/install/airgap.adoc
+++ b/versions/latest/modules/zh/pages/install/airgap.adoc
@@ -3,7 +3,7 @@
 :revdate: 2025-06-18
 :page-revdate: {revdate}
 
-{product-name} can be installed in an air-gapped environment with two different methods. You can either deploy via the `rke2-airgap-images` tarball artifact or by using a private registry.
+To install {product-name} can be installed in an air-gapped environment, you must first load the images into the air-gapped environment and then install RKE2.
 
 [IMPORTANT]
 ====
@@ -16,11 +16,11 @@ Ensure you meet the following prerequisites based on your environment before pro
 
 [CAUTION]
 ====
-If your node has NetworkManager installed and enabled, xref:../known_issues.adoc#_networkmanager[ensure you configure NetworkManager to ignore CNI-managed interfaces].
+If your node has NetworkManager installed and enabled, xref:known_issues.adoc#_networkmanager[ensure you configure NetworkManager to ignore CNI-managed interfaces].
 ====
 
-* If running on an air-gapped node with SELinux enabled, you must manually install the necessary SELinux policy RPM before performing these steps. See our xref:./methods.adoc#_rpm[RPM Documentation] to determine what you need.
-* If running on an air-gapped node with SELinux enabled, the following are required dependencies for SLES, CentOS, or RHEL 8 when doing an xref:./methods.adoc#_rpm[RPM install]: `container-selinux iptables libnetfilter_conntrack libnfnetlink libnftnl policycoreutils-python-utils rke2-common rke2-selinux`
+* If running on an air-gapped node with SELinux enabled, you must manually install the necessary SELinux policy RPM before performing these steps. See our xref:install/methods.adoc#_rpm[RPM Documentation] to determine what you need.
+* If running on an air-gapped node with SELinux enabled, the following are required dependencies for SLES, CentOS, or RHEL 8 when doing an xref:install/methods.adoc#_rpm[RPM install]: `container-selinux iptables libnetfilter_conntrack libnfnetlink libnftnl policycoreutils-python-utils rke2-common rke2-selinux`
 * If your nodes do not have an interface with a default route, a default route must be configured; even a black-hole route via a dummy interface will suffice.  RKE2 requires a default route to auto-detect the node's primary IP and for kube-proxy ClusterIP routing to function correctly. To add a dummy route, do the following:
 +
 [,bash]
@@ -31,7 +31,12 @@ ip addr add 203.0.113.254/31 dev dummy0
 ip route add default via 203.0.113.255 dev dummy0 metric 1000
 ----
 
-== Tarball Method
+== 1. Load Images
+
+There are two different methods to load the images. Each image loading method has different requirements and is suited for different air-gapped scenarios. Choose the method that best fits your infrastructure and security requirements.
+
+
+=== Tarball Method
 
 . Download the air-gap images tarballs from the https://scc.suse.com/rancher-docs/rancherprime/latest/en/reference-guide.html#prime-artifacts-url[Prime Artifacts URL] for the RKE2 version, CNI, and platform you are using.
  ** `rke2-images.linux-<ARCH>.tar.zst`, or `rke2-images-core.linux-<ARCH>.tar.gz`. This tarball contains the core container images required for RKE2 Prime to function. Zstandard offers better compression ratios and faster decompression speeds compared to gzip.
@@ -41,16 +46,18 @@ ip route add default via 203.0.113.255 dev dummy0 metric 1000
  *** If using your own CNI (`--cni=none`), download only the `rke2-images-core` archive.
  ** If enabling the vSphere CPI/CSI charts (`--cloud-provider-name=rancher-vsphere`), you must also download the `rke2-images-vsphere` archive.
 . Create a directory named `/rke2-artifacts` on the node and save the previously downloaded files there.
-. <<Install RKE2>>.
+. <<2. Install RKE2, Istall RKE2>>.
 
-== Private Registry Method
 
-Private registry support honors all settings from the xref:./containerd_registry_configuration.adoc[containerd registry configuration], including endpoint override, transport protocol (HTTP/HTTPS), authentication, certificate verification, and more.
+=== Private Registry Method
+
+Private registry support honors all settings from the xref:install/containerd_registry_configuration.adoc[containerd registry configuration], including endpoint override, transport protocol (HTTP/HTTPS), authentication, certificate verification, and more.
 
 . Add all the required system images to your private registry. A list of images can be obtained from the `.txt` file corresponding to each tarball referenced above. Alternatively, you can `docker load` the airgap image tarballs, then tag and push the loaded images.
-. <<Install RKE2>> using the `system-default-registry` parameter, or use the xref:./containerd_registry_configuration.adoc[containerd registry configuration] to use your registry as a mirror for docker.io.
+. <<2. Install RKE2, Install RKE2>> using the `system-default-registry` parameter, or use the xref:install/containerd_registry_configuration.adoc[containerd registry configuration] to use your registry as a mirror for docker.io.
 
-== Install RKE2
+
+== 2. Install RKE2
 
 The following options to install RKE2 should only be performed after completing either the <<Tarball Method>> or <<Private Registry Method>>.
 
@@ -86,7 +93,7 @@ The `system-default-registry` parameter must specify only valid RFC 3986 URI aut
 
 `install.sh` may be used in an offline mode by setting the `INSTALL_RKE2_ARTIFACT_PATH` variable to a path containing pre-downloaded artifacts. This will run through a standard install, including creating systemd units.
 
-. Download the install script, RKE2 binaires, RKE2 images, and SHA256 checksums archives from the https://scc.suse.com/rancher-docs/rancherprime/latest/en/reference-guide.html#prime-artifacts-url[Prime Artifacts URL] into the `/rke2-artifacts` directory, as in the example below:
+. Download the install script, RKE2 binaries, RKE2 images, and SHA256 checksums archives from the https://scc.suse.com/rancher-docs/rancherprime/latest/en/reference-guide.html#prime-artifacts-url[Prime Artifacts URL] into the `/rke2-artifacts` directory, as in the example below:
 +
 [,bash]
 ----
@@ -104,4 +111,14 @@ curl -sfL https://get.rke2.io --output install.sh
 INSTALL_RKE2_ARTIFACT_PATH=/rke2-artifacts sh install.sh
 ----
 
-. Enable and run the service as outlined xref:./quickstart.adoc#_2_enable_the_rke2_server_service[here].
+. If you are using the Rancher Prime registry, set the following values in `config.yaml`:
+.. Set `system-default-registry: registry.rancher.com`.
+.. If you are not using the default CNI, Canal, set `cni: <CNI>`.
++
+[,yaml]
+----
+system-default-registry: registry.rancher.com
+cni: <CNI>
+----
+
+. Enable and run the service as outlined xref:install/quickstart.adoc[here].


### PR DESCRIPTION
This PR adds one important missing step when installing RKE2 using the script. Moreover, it partially syncs with the community does which define 2 steps: 1-Load images, 2-Install RKE2