### PR TITLE
Fix broken xrefs per current springio/antora-xref-extension logs Pt 3

### DIFF
--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -327,7 +327,7 @@ In case of IPv6 only configuration RKE2 needs to use `localhost` to access the l
 If your IPv6 default route is set by a router advertisement (RA), you will need to set the sysctl `net.ipv6.conf.all.accept_ra=2`. Otherwise, the node will drop the default route once it expires. Be aware that accepting RAs could increase the risk of https://github.com/kubernetes/kubernetes/issues/91507[man-in-the-middle attacks].
 ====
 
-In IPv6-only mode, Cilium does not support encapsulation of IPv6 traffic between nodes. Communication between pods on different nodes relies on the host's network to properly route packets to pod IPs. Cilium can be configured to automatically manage static routes between nodes with the following configuration::
+In IPv6-only mode, Cilium does not support encapsulation of IPv6 traffic between nodes. Communication between pods on different nodes relies on the host's network to properly route packets to pod IPs. Cilium can be configured to automatically manage static routes between nodes with the following configuration:
 
 [,yaml]
 ----

--- a/versions/latest/modules/zh/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/zh/pages/networking/basic_network_options.adoc
@@ -326,7 +326,7 @@ In case of IPv6 only configuration RKE2 needs to use `localhost` to access the l
 If your IPv6 default route is set by a router advertisement (RA), you will need to set the sysctl `net.ipv6.conf.all.accept_ra=2`. Otherwise, the node will drop the default route once it expires. Be aware that accepting RAs could increase the risk of https://github.com/kubernetes/kubernetes/issues/91507[man-in-the-middle attacks].
 ====
 
-In IPv6-only mode, Cilium does not support encapsulation of IPv6 traffic between nodes. Communication between pods on different nodes relies on the host's network to properly route packets to pod IPs. Cilium can be configured to automatically manage static routes between nodes with the following configuration::
+In IPv6-only mode, Cilium does not support encapsulation of IPv6 traffic between nodes. Communication between pods on different nodes relies on the host's network to properly route packets to pod IPs. Cilium can be configured to automatically manage static routes between nodes with the following configuration:
 
 [,yaml]
 ----

--- a/versions/latest/modules/zh/pages/reference/linux_agent_config.adoc
+++ b/versions/latest/modules/zh/pages/reference/linux_agent_config.adoc
@@ -3,7 +3,7 @@
 :revdate: 2024-09-11
 :page-revdate: {revdate}
 
-本文提供了可用于配置 RKE2 Agent 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_配置文件[配置文件]。
+本文提供了可用于配置 RKE2 Agent 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_configuration_file[配置文件]。
 
 == RKE2 Agent CLI 帮助
 

--- a/versions/latest/modules/zh/pages/reference/server_config.adoc
+++ b/versions/latest/modules/zh/pages/reference/server_config.adoc
@@ -3,7 +3,7 @@
 :revdate: 2026-04-01
 :page-revdate: {revdate}
 
-本文提供了可用于配置 RKE2 Server 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_配置文件[配置文件]。
+本文提供了可用于配置 RKE2 Server 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_configuration_file[配置文件]。
 
 == Critical Configuration Values
 


### PR DESCRIPTION
- [x] Resolve remaining `ERROR (asciidoctor): target fragment of xref not found` errors
- [x] Resolve `WARN (asciidoctor): Parse error when validating xrefs (node.getLogger is not a function)`
  - This was caused by a typo (`::`) 