### PR TITLE
Fix incorrect port number in registry_mirror.adoc

### DIFF
--- a/versions/latest/modules/en/pages/install/registry_mirror.adoc
+++ b/versions/latest/modules/en/pages/install/registry_mirror.adoc
@@ -1,6 +1,6 @@
 = Embedded Registry Mirror
 :page-languages: [en, zh]
-:revdate: 2025-10-29
+:revdate: 2026-05-11
 :page-revdate: {revdate}
 
 [NOTE]
@@ -15,7 +15,7 @@ RKE2 embeds https://github.com/spegel-org/spegel[Spegel], a stateless distribute
 
 In order to enable the embedded registry mirror, server nodes must be configured with `embedded-registry: true`. This option enables the embedded mirror for use on all nodes in the cluster.
 
-When enabled at a cluster level, all nodes will host a local OCI registry on port 6443, and publish a list of available images via a peer to peer network on port 5001. Any image available in the containerd image store on any node, can be pulled by other cluster members without access to an external registry. Images imported via xref:install/airgap.adoc#_tarball_method[air-gap image tar files] or xref:add-ons/import_images.adoc#_pre_import_images[pre-imported] are pinned in containerd to ensure that they remain available and are not pruned by Kubelet garbage collection.
+When enabled at a cluster level, all nodes will host a local OCI registry on port 9345, and publish a list of available images via a peer to peer network on port 5001. Any image available in the containerd image store on any node, can be pulled by other cluster members without access to an external registry. Images imported via xref:install/airgap.adoc#_tarball_method[air-gap image tar files] or xref:add-ons/import_images.adoc#_pre_import_images[pre-imported] are pinned in containerd to ensure that they remain available and are not pruned by Kubelet garbage collection.
 
 === Requirements
 

--- a/versions/latest/modules/zh/pages/install/registry_mirror.adoc
+++ b/versions/latest/modules/zh/pages/install/registry_mirror.adoc
@@ -1,6 +1,6 @@
 = Embedded Registry Mirror
 :page-languages: [en, zh]
-:revdate: 2025-10-29
+:revdate: 2026-05-11
 :page-revdate: {revdate}
 
 [NOTE]
@@ -15,7 +15,7 @@ RKE2 embeds https://github.com/spegel-org/spegel[Spegel], a stateless distribute
 
 In order to enable the embedded registry mirror, server nodes must be configured with `embedded-registry: true`. This option enables the embedded mirror for use on all nodes in the cluster.
 
-When enabled at a cluster level, all nodes will host a local OCI registry on port 6443, and publish a list of available images via a peer to peer network on port 5001. Any image available in the containerd image store on any node, can be pulled by other cluster members without access to an external registry. Images imported via xref:install/airgap.adoc#_tarball_method[air-gap image tar files] or xref:add-ons/import_images.adoc#_pre_import_images[pre-imported] are pinned in containerd to ensure that they remain available and are not pruned by Kubelet garbage collection.
+When enabled at a cluster level, all nodes will host a local OCI registry on port 9345, and publish a list of available images via a peer to peer network on port 5001. Any image available in the containerd image store on any node, can be pulled by other cluster members without access to an external registry. Images imported via xref:install/airgap.adoc#_tarball_method[air-gap image tar files] or xref:add-ons/import_images.adoc#_pre_import_images[pre-imported] are pinned in containerd to ensure that they remain available and are not pruned by Kubelet garbage collection.
 
 === Requirements
 


### PR DESCRIPTION
The embedded registry mirror runs on port 9345, not 6443. This error was introduced in commit 9fc5f207e3.

Updated both en and zh versions to match rke2-docs.