### PR TITLE
[sync rke2-docs] Update networking services with kube-proxy IPVS deprecation

### DIFF
--- a/versions/latest/modules/en/pages/networking/networking_services.adoc
+++ b/versions/latest/modules/en/pages/networking/networking_services.adoc
@@ -1,6 +1,6 @@
 = Networking Services
 :page-languages: [en, zh]
-:revdate: 2026-03-16
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 This page explains how CoreDNS and the Nginx-Ingress controller work within RKE2.
@@ -37,6 +37,11 @@ spec:
 
 The helm controller will redeploy coredns with the new config. Please be aware that nodelocal modifies the iptables of the node to intercept DNS traffic. Therefore, activating and then deactivating this feature without redeploying, will cause the DNS service to stop working.
 
+[WARNING]
+====
+`kube-proxy` in IPVS mode is officially https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/#deprecation-of-ipvs-mode-in-kube-proxy[deprecated] starting in Kubernetes v1.35. While it remains functional in v1.35, it is scheduled for removal in a future release.
+====
+
 Note that NodeLocal DNSCache must be deployed in ipvs mode if kube-proxy is using that mode. To deploy it in this mode, apply the following HelmChartConfig:
 
 [,yaml]
@@ -52,6 +57,14 @@ spec:
     nodelocal:
       enabled: true
       ipvs: true
+----
+
+When using kube-proxy in IPVS mode, all nodes must be configured to use the node-local address for cluster DNS, instead of the in-cluster service endpoint. Note that this setting will only take effect after a restart of the RKE2 service and all running pods.
+
+[,yaml]
+----
+kubelet-arg:
+    - "cluster-dns=169.254.20.10"
 ----
 
 === NodeLocal DNS Cache with Cilium in kube-proxy replacement mode

--- a/versions/latest/modules/zh/pages/networking/networking_services.adoc
+++ b/versions/latest/modules/zh/pages/networking/networking_services.adoc
@@ -1,6 +1,6 @@
 = Networking Services
 :page-languages: [en, zh]
-:revdate: 2026-03-16
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 This page explains how CoreDNS and the Nginx-Ingress controller work within RKE2.
@@ -37,6 +37,11 @@ spec:
 
 The helm controller will redeploy coredns with the new config. Please be aware that nodelocal modifies the iptables of the node to intercept DNS traffic. Therefore, activating and then deactivating this feature without redeploying, will cause the DNS service to stop working.
 
+[WARNING]
+====
+`kube-proxy` in IPVS mode is officially https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/#deprecation-of-ipvs-mode-in-kube-proxy[deprecated] starting in Kubernetes v1.35. While it remains functional in v1.35, it is scheduled for removal in a future release.
+====
+
 Note that NodeLocal DNSCache must be deployed in ipvs mode if kube-proxy is using that mode. To deploy it in this mode, apply the following HelmChartConfig:
 
 [,yaml]
@@ -52,6 +57,14 @@ spec:
     nodelocal:
       enabled: true
       ipvs: true
+----
+
+When using kube-proxy in IPVS mode, all nodes must be configured to use the node-local address for cluster DNS, instead of the in-cluster service endpoint. Note that this setting will only take effect after a restart of the RKE2 service and all running pods.
+
+[,yaml]
+----
+kubelet-arg:
+    - "cluster-dns=169.254.20.10"
 ----
 
 === NodeLocal DNS Cache with Cilium in kube-proxy replacement mode


### PR DESCRIPTION
This sync combines multiple commits from rke2-docs (98f2031, 5c46c8e, c4b6e1e, 925f273, e596cf7):
- Add deprecation warning for kube-proxy in IPVS mode (deprecated in K8s v1.35)
- Document kubelet-arg configuration for cluster-dns when using kube-proxy in IPVS mode
- Clarify NodeLocal DNSCache requirements with kube-proxy IPVS mode