### PR TITLE
[sync rke2-docs] Update Server and Agent reference pages

### DIFF
--- a/versions/latest/modules/en/pages/reference/linux_agent_config.adoc
+++ b/versions/latest/modules/en/pages/reference/linux_agent_config.adoc
@@ -1,9 +1,9 @@
 = Agent Configuration Reference
 :page-languages: [en, zh]
-:revdate: 2025-08-21
+:revdate: 2026-06-19
 :page-revdate: {revdate}
 
-This is a reference to all parameters that can be used to configure the RKE2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:../install/configuration.adoc#_configuration_file[configuration file].
+This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#configuration-file[configuration file].
 
 == Common
 
@@ -17,13 +17,14 @@ This is a reference to all parameters that can be used to configure the RKE2 age
 
 | debug
 | Turn on debug logs
-|
+| false
 | RKE2_DEBUG
 
 | data-dir
 | Folder to hold state
 | "/var/lib/rancher/rke2"
-|
+| RKE2_DATA_DIR
+
 |===
 
 == Cluster
@@ -42,120 +43,104 @@ This is a reference to all parameters that can be used to configure the RKE2 age
 | server
 | Server to connect to
 | RKE2_URL
-|===
-
-== Node
 
 |===
-| Flag | Description | Default | Environment Variable
 
-| node-name
-| Node name
-|
-| RKE2_NODE_NAME
-
-| with-node-id
-| Append id to node name
-|
-|
-
-| node-label
-| Registering and starting kubelet with set of labels
-|
-|
-
-| node-taint
-| Registering kubelet with set of taints
-|
-|
-
-| image-credential-provider-bin-dir
-| The path to the directory where credential provider plugin binaries are located
-| "/var/lib/rancher/credentialprovider/bin"
-|
-
-| image-credential-provider-config
-| The path to the credential provider plugin config file
-| "/var/lib/rancher/credentialprovider/config.yaml"
-|
-
-| selinux
-| Enable SELinux in containerd
-|
-| RKE2_SELINUX
-
-| lb-server-port
-| Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.
-| 6444
-| RKE2_LB_SERVER_PORT
-
-| protect-kernel-defaults
-| Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
-|
-|
-|===
-
-== Runtime
+== Listener
 
 |===
 | Flag | Description | Default
 
-| container-runtime-endpoint
-| Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path
-|
-
-| default-runtime
-| Set the default runtime in containerd
-|
-
-| snapshotter
-| Override default containerd snapshotter
-| "overlayfs"
-
-| private-registry
-| Private registry configuration file
-| "/etc/rancher/rke2/registries.yaml"
-|===
-
-== Containerd
+| bind-address
+| rke2 bind address
+| 0.0.0.0
 
 |===
-| Flag | Description
 
-| disable-default-registry-endpoint
-| Disables containerd's fallback default registry endpoint when a mirror is configured for that registry
-|===
-
-== Networking
+== Image
 
 |===
 | Flag | Description | Environment Variable
 
-| node-ip
-| IPv4/IPv6 addresses to advertise for node
-|
+| kube-apiserver-image
+| Override image to use for kube-apiserver
+| RKE2_KUBE_APISERVER_IMAGE
 
-| node-external-ip
-| IPv4/IPv6 external IP addresses to advertise for node
-|
+| kube-controller-manager-image
+| Override image to use for kube-controller-manager
+| RKE2_KUBE_CONTROLLER_MANAGER_IMAGE
 
-| resolv-conf
-| Kubelet resolv.conf file
-| RKE2_RESOLV_CONF
+| cloud-controller-manager-image
+| Override image to use for cloud-controller-manager
+| RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE
+
+| kube-proxy-image
+| Override image to use for kube-proxy
+| RKE2_KUBE_PROXY_IMAGE
+
+| kube-scheduler-image
+| Override image to use for kube-scheduler
+| RKE2_KUBE_SCHEDULER_IMAGE
+
+| pause-image
+| Override image to use for pause
+| RKE2_PAUSE_IMAGE
+
+| runtime-image
+| Override image to use for runtime binaries (containerd, kubectl, crictl, etc)
+| RKE2_RUNTIME_IMAGE
+
+| etcd-image
+| Override image to use for etcd
+| RKE2_ETCD_IMAGE
+
+|===
+
+== Cloud Provider
+
+|===
+| Flag | Description | Default | Environment Variable
+
+| cloud-provider-name
+| Cloud provider name
+| 
+| RKE2_CLOUD_PROVIDER_NAME
+
+| cloud-provider-config
+| Cloud provider configuration file path
+| 
+| RKE2_CLOUD_PROVIDER_CONFIG
+
+| node-name-from-cloud-provider-metadata
+| Set node name from instance metadata service hostname
+| false
+| RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA
+
+|===
+
+== Security
+
+|===
+| Flag | Description | Environment Variable
+
+| profile
+| Validate system configuration against the selected benchmark (valid items: cis, etcd)
+| RKE2_CIS_PROFILE
+
+| audit-policy-file
+| Path to the file that defines the audit policy configuration
+| RKE2_AUDIT_POLICY_FILE
+
+| pod-security-admission-config-file
+| Path to the file that defines Pod Security Admission configuration
+| RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE
+
 |===
 
 == Components
 
 |===
 | Flag | Description | Environment Variable
-
-| kubelet-arg
-| Customized flag for kubelet process
-|
-
-| kube-proxy-arg
-| Customized flag for kube-proxy process
-|
 
 | control-plane-resource-requests
 | Control Plane resource requests
@@ -216,84 +201,153 @@ This is a reference to all parameters that can be used to configure the RKE2 age
 | cloud-controller-manager-extra-env
 | cloud-controller-manager extra environment variables
 | RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV
+
 |===
 
-== Image
+== Node
+
+|===
+| Flag | Description | Default | Environment Variable
+
+| node-name
+| Node name
+| 
+| RKE2_NODE_NAME
+
+| with-node-id
+| Append id to node name
+| false
+| 
+
+| node-label
+| Registering and starting kubelet with set of labels
+| 
+| 
+
+| node-taint
+| Registering kubelet with set of taints
+| 
+| 
+
+| image-credential-provider-bin-dir
+| The path to the directory where credential provider plugin binaries are located
+| "/var/lib/rancher/credentialprovider/bin"
+| 
+
+| image-credential-provider-config
+| The path to the credential provider plugin config file
+| "/var/lib/rancher/credentialprovider/config.yaml"
+| 
+
+| selinux
+| Enable SELinux in containerd
+| false
+| RKE2_SELINUX
+
+| lb-server-port
+| Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.
+| 6444
+| RKE2_LB_SERVER_PORT
+
+| protect-kernel-defaults
+| Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
+| false
+| 
+
+|===
+
+== Runtime
+
+|===
+| Flag | Description | Default
+
+| container-runtime-endpoint
+| Disable embedded containerd and use the CRI socket at the given path
+| 
+
+| default-runtime
+| Set the default runtime in containerd
+| 
+
+| snapshotter
+| Override default containerd snapshotter
+| "overlayfs"
+
+| private-registry
+| Private registry configuration file
+| "/etc/rancher/rke2/registries.yaml"
+
+|===
+
+== Containerd
+
+|===
+| Flag | Description | Default
+
+| disable-default-registry-endpoint
+| Disables containerd's fallback default registry endpoint when a mirror is configured for that registry
+| false
+
+| nonroot-devices
+| Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config
+| false
+
+|===
+
+== Networking
 
 |===
 | Flag | Description | Environment Variable
 
-| kube-apiserver-image
-| Override image to use for kube-apiserver
-| RKE2_KUBE_APISERVER_IMAGE
+| node-ip
+| IPv4/IPv6 addresses to advertise for node
+| 
 
-| kube-controller-manager-image
-| Override image to use for kube-controller-manager
-| RKE2_KUBE_CONTROLLER_MANAGER_IMAGE
+| node-external-ip
+| IPv4/IPv6 external IP addresses to advertise for node
+| 
 
-| cloud-controller-manager-image
-| Override image to use for cloud-controller-manager
-| RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE
+| node-internal-dns
+| internal DNS addresses to advertise for node
+| 
 
-| kube-proxy-image
-| Override image to use for kube-proxy
-| RKE2_KUBE_PROXY_IMAGE
+| node-external-dns
+| external DNS addresses to advertise for node
+| 
 
-| kube-scheduler-image
-| Override image to use for kube-scheduler
-| RKE2_KUBE_SCHEDULER_IMAGE
-
-| pause-image
-| Override image to use for pause
-| RKE2_PAUSE_IMAGE
-
-| runtime-image
-| Override image to use for runtime binaries (containerd, kubectl, crictl, etc)
-| RKE2_RUNTIME_IMAGE
-
-| etcd-image
-| Override image to use for etcd
-| RKE2_ETCD_IMAGE
-|===
-
-== Cloud Provider
+| resolv-conf
+| Kubelet resolv.conf file
+| RKE2_RESOLV_CONF
 
 |===
-| Flag | Description | Environment Variable
 
-| cloud-provider-name
-| Cloud provider name
-| RKE2_CLOUD_PROVIDER_NAME
-
-| cloud-provider-config
-| Cloud provider configuration file path
-| RKE2_CLOUD_PROVIDER_CONFIG
-|===
-
-== Security
+== Flags
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description
 
-| profile
-| Validate system configuration against the selected benchmark (valid items: cis, cis-1.23 (deprecated))
-| RKE2_CIS_PROFILE
+| kubelet-arg
+| Customized flag for kubelet process
 
-| audit-policy-file
-| Path to the file that defines the audit policy configuration
-| RKE2_AUDIT_POLICY_FILE
+| kube-proxy-arg
+| Customized flag for kube-proxy process
 
-| pod-security-admission-config-file
-| Path to the file that defines Pod Security Admission configuration
-| RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE
 |===
 
 == Experimental
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description | Default | Environment Variable
+
+| enable-pprof
+| Enable pprof endpoint on supervisor port
+| false
+| 
 
 | kubelet-path
 | Override kubelet binary path
+| 
 | RKE2_KUBELET_PATH
+
 |===
+

--- a/versions/latest/modules/en/pages/reference/linux_agent_config.adoc
+++ b/versions/latest/modules/en/pages/reference/linux_agent_config.adoc
@@ -3,7 +3,7 @@
 :revdate: 2026-06-19
 :page-revdate: {revdate}
 
-This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#configuration-file[configuration file].
+This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#_configuration_file[configuration file].
 
 == Common
 

--- a/versions/latest/modules/en/pages/reference/server_config.adoc
+++ b/versions/latest/modules/en/pages/reference/server_config.adoc
@@ -3,9 +3,9 @@
 :revdate: 2026-06-19
 :page-revdate: {revdate}
 
-This is a reference to all parameters that can be used to configure the rke2 server. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#configuration-file[configuration file].
+This is a reference to all parameters that can be used to configure the rke2 server. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#_configuration_file[configuration file].
 
-=== Critical Configuration Values
+==Critical Configuration Values
 
 The following options must be set to the same value on all servers in the cluster. Failure to do so will cause new servers to fail to join the cluster.
 
@@ -18,7 +18,7 @@ The following options must be set to the same value on all servers in the cluste
 * `egress-selector-mode`
 * `service-cidr`
 
-=== Common
+==Common
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -40,7 +40,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Listener
+==Listener
 
 |===
 | Flag | Description | Default
@@ -63,7 +63,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Networking
+==Networking
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -115,7 +115,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Client
+==Client
 
 |===
 | Flag | Description | Environment Variable
@@ -134,7 +134,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Helm
+==Helm
 
 |===
 | Flag | Description
@@ -144,7 +144,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Cluster
+==Cluster
 
 |===
 | Flag | Description | Environment Variable
@@ -175,7 +175,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Database
+==Database
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -247,7 +247,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== S3 etcd Snapshot Storage
+==S3 etcd Snapshot Storage
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -334,7 +334,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Flags
+==Flags
 
 |===
 | Flag | Description
@@ -356,7 +356,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Components
+==Components
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -468,7 +468,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Image
+==Image
 
 |===
 | Flag | Description | Environment Variable
@@ -507,7 +507,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Cloud Provider
+==Cloud Provider
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -529,7 +529,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Security
+==Security
 
 |===
 | Flag | Description | Environment Variable
@@ -548,7 +548,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Experimental
+==Experimental
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -575,7 +575,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Node
+==Agent/Node
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -627,7 +627,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Runtime
+==Agent/Runtime
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -659,7 +659,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Containerd
+==Agent/Containerd
 
 |===
 | Flag | Description | Default
@@ -674,7 +674,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Networking
+==Agent/Networking
 
 |===
 | Flag | Description | Environment Variable
@@ -701,7 +701,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Flags
+==Agent/Flags
 
 |===
 | Flag | Description

--- a/versions/latest/modules/en/pages/reference/server_config.adoc
+++ b/versions/latest/modules/en/pages/reference/server_config.adoc
@@ -5,7 +5,7 @@
 
 This is a reference to all parameters that can be used to configure the rke2 server. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#_configuration_file[configuration file].
 
-==Critical Configuration Values
+== Critical Configuration Values
 
 The following options must be set to the same value on all servers in the cluster. Failure to do so will cause new servers to fail to join the cluster.
 
@@ -18,7 +18,7 @@ The following options must be set to the same value on all servers in the cluste
 * `egress-selector-mode`
 * `service-cidr`
 
-==Common
+== Common
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -40,7 +40,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Listener
+== Listener
 
 |===
 | Flag | Description | Default
@@ -63,7 +63,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Networking
+== Networking
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -115,7 +115,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Client
+== Client
 
 |===
 | Flag | Description | Environment Variable
@@ -134,7 +134,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Helm
+== Helm
 
 |===
 | Flag | Description
@@ -144,7 +144,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Cluster
+== Cluster
 
 |===
 | Flag | Description | Environment Variable
@@ -175,7 +175,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Database
+== Database
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -247,7 +247,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==S3 etcd Snapshot Storage
+== S3 etcd Snapshot Storage
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -334,7 +334,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Flags
+== Flags
 
 |===
 | Flag | Description
@@ -356,7 +356,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Components
+== Components
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -468,7 +468,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Image
+== Image
 
 |===
 | Flag | Description | Environment Variable
@@ -507,7 +507,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Cloud Provider
+== Cloud Provider
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -529,7 +529,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Security
+== Security
 
 |===
 | Flag | Description | Environment Variable
@@ -548,7 +548,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Experimental
+== Experimental
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -575,7 +575,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Node
+== Agent/Node
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -627,7 +627,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Runtime
+== Agent/Runtime
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -659,7 +659,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Containerd
+== Agent/Containerd
 
 |===
 | Flag | Description | Default
@@ -674,7 +674,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Networking
+== Agent/Networking
 
 |===
 | Flag | Description | Environment Variable
@@ -701,7 +701,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Flags
+== Agent/Flags
 
 |===
 | Flag | Description

--- a/versions/latest/modules/en/pages/reference/server_config.adoc
+++ b/versions/latest/modules/en/pages/reference/server_config.adoc
@@ -1,11 +1,11 @@
 = Server Configuration Reference
 :page-languages: [en, zh]
-:revdate: 2026-04-01
+:revdate: 2026-06-19
 :page-revdate: {revdate}
 
-This is a reference to all parameters that can be used to configure the rke2 server. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#_configuration_file[configuration file].
+This is a reference to all parameters that can be used to configure the rke2 server. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#configuration-file[configuration file].
 
-== Critical Configuration Values
+=== Critical Configuration Values
 
 The following options must be set to the same value on all servers in the cluster. Failure to do so will cause new servers to fail to join the cluster.
 
@@ -30,13 +30,14 @@ The following options must be set to the same value on all servers in the cluste
 
 | debug
 | Turn on debug logs
-|
+| false
 | RKE2_DEBUG
 
 | data-dir
 | Folder to hold state
 | "/var/lib/rancher/rke2"
-|
+| RKE2_DATA_DIR
+
 |===
 
 === Listener
@@ -54,11 +55,12 @@ The following options must be set to the same value on all servers in the cluste
 
 | tls-san
 | Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert
-|
+| 
 
 | tls-san-security
 | Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option
 | true
+
 |===
 
 === Networking
@@ -69,42 +71,48 @@ The following options must be set to the same value on all servers in the cluste
 | cluster-cidr
 | IPv4/IPv6 network CIDRs to use for pod IPs
 | 10.42.0.0/16
-|
+| 
 
 | service-cidr
 | IPv4/IPv6 network CIDRs to use for service IPs
 | 10.43.0.0/16
-|
+| 
 
 | service-node-port-range
 | Port range to reserve for services with NodePort visibility
 | "30000-32767"
-|
+| 
 
 | cluster-dns
-| IPv4 Cluster IP for coredns service. Should be in your service-cidr range
+| IPv4/IPv6 Cluster IP for coredns service. Should be in your service-cidr range
 | 10.43.0.10
-|
+| 
 
 | cluster-domain
 | Cluster Domain
 | "cluster.local"
-|
+| 
 
 | egress-selector-mode
 | One of 'agent', 'cluster', 'pod', 'disabled'
 | "agent"
-|
+| 
 
 | servicelb-namespace
 | Namespace of the pods for the servicelb component
 | "kube-system"
-|
+| 
 
 | cni
-| CNI Plugins to deploy, one of none, calico, canal, cilium; optionally with multus as the first value to enable the multus meta-plugin
-| canal
+| CNI Plugins to deploy, one of none, calico, canal, cilium, flannel; optionally with multus as the first value to enable the multus meta-plugin
+| "canal"
 | RKE2_CNI
+
+| ingress-controller
+| Ingress Controllers to deploy, one of none, traefik, ingress-nginx; the first value will be set as the default ingress class
+| 
+| RKE2_INGRESS_CONTROLLER
+
 |===
 
 === Client
@@ -119,6 +127,11 @@ The following options must be set to the same value on all servers in the cluste
 | write-kubeconfig-mode
 | Write kubeconfig with this mode
 | RKE2_KUBECONFIG_MODE
+
+| write-kubeconfig-group
+| Write kubeconfig with this group
+| RKE2_KUBECONFIG_GROUP
+
 |===
 
 === Helm
@@ -128,6 +141,7 @@ The following options must be set to the same value on all servers in the cluste
 
 | helm-job-image
 | Default image to use for helm jobs
+
 |===
 
 === Cluster
@@ -158,6 +172,7 @@ The following options must be set to the same value on all servers in the cluste
 | cluster-reset
 | Forget all peers and become sole member of a new cluster
 | RKE2_CLUSTER_RESET
+
 |===
 
 === Database
@@ -167,43 +182,69 @@ The following options must be set to the same value on all servers in the cluste
 
 | cluster-reset-restore-path
 | Path to snapshot file to be restored
-|
-|
+| 
+| 
+
+| datastore-endpoint
+| Specify etcd, NATS, MySQL, Postgres, or SQLite  data source name
+| sqlite
+| RKE2_DATASTORE_ENDPOINT
+
+| datastore-cafile
+| TLS Certificate Authority file used to secure datastore backend communication
+| 
+| RKE2_DATASTORE_CAFILE
+
+| datastore-certfile
+| TLS certification file used to secure datastore backend communication
+| 
+| RKE2_DATASTORE_CERTFILE
+
+| datastore-keyfile
+| TLS key file used to secure datastore backend communication
+| 
+| RKE2_DATASTORE_KEYFILE
 
 | etcd-expose-metrics
-| Expose etcd metrics to client interface.
+| Expose etcd metrics to client interface
 | false
-|
+| 
 
 | etcd-disable-snapshots
 | Disable automatic etcd snapshots
-|
-|
+| false
+| 
 
 | etcd-snapshot-name
-| Set the base name of etcd snapshots
-| etcd-snapshot-<unix-timestamp>)
-|
+| Set the base name of etcd snapshots, appended with UNIX timestamp
+| "etcd-snapshot"
+| 
 
 | etcd-snapshot-schedule-cron
 | Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'
 | "0 */12 * * *"
-|
+| 
+
+| etcd-snapshot-reconcile-interval
+| Snapshot reconcile interval
+| 10m0s
+| 
 
 | etcd-snapshot-retention
 | Number of snapshots to retain
 | 5
-|
+| 
 
 | etcd-snapshot-dir
 | Directory to save db snapshots.
-| $&#123;data-dir&#125;/db/snapshots
-|
+| $&#123;data-dir&#125;/server/db/snapshots
+| 
 
 | etcd-snapshot-compress
 | Compress etcd snapshot
-|
-|
+| false
+| 
+
 |===
 
 === S3 etcd Snapshot Storage
@@ -213,7 +254,7 @@ The following options must be set to the same value on all servers in the cluste
 
 | etcd-s3
 | Enable backup to S3
-| 
+| false
 | 
 
 | etcd-s3-endpoint
@@ -228,7 +269,7 @@ The following options must be set to the same value on all servers in the cluste
 
 | etcd-s3-skip-ssl-verify
 | Disables S3 SSL certificate validation
-| 
+| false
 | 
 
 | etcd-s3-access-key
@@ -252,8 +293,8 @@ The following options must be set to the same value on all servers in the cluste
 | 
 
 | etcd-s3-bucket-lookup-type
-| S3 bucket lookup type, one of 'auto', 'dns', 'path'
-| "auto"
+| S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set
+| 
 | 
 
 | etcd-s3-region
@@ -283,13 +324,14 @@ The following options must be set to the same value on all servers in the cluste
 
 | etcd-s3-insecure
 | Disables S3 over HTTPS
-| 
+| false
 | 
 
 | etcd-s3-timeout
 | S3 timeout
 | 5m0s
 | 
+
 |===
 
 === Flags
@@ -311,96 +353,118 @@ The following options must be set to the same value on all servers in the cluste
 
 | kube-cloud-controller-manager-arg
 | Customized flag for kube-cloud-controller-manager process
+
 |===
 
 === Components
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description | Default | Environment Variable
 
 | disable
-| Do not deploy packaged components and delete any deployed components (valid items: rke2-coredns, rke2-ingress-nginx, rke2-metrics-server)
-|
+| Do not deploy packaged components and delete any deployed components (valid items: rke2-coredns, rke2-metrics-server, rke2-snapshot-controller, rke2-snapshot-controller-crd, rke2-snapshot-validation-webhook)
+| 
+| 
 
 | disable-scheduler
 | Disable Kubernetes default scheduler
-|
+| false
+| 
 
 | disable-cloud-controller
 | Disable rke2 default cloud controller manager
-|
+| false
+| 
 
 | disable-kube-proxy
 | Disable running kube-proxy
-|
+| false
+| 
+
+| embedded-registry
+| Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port
+| false
+| 
 
 | enable-servicelb
 | Enable rke2 default cloud controller manager's service controller
+| false
 | RKE2_ENABLE_SERVICELB
 
 | control-plane-resource-requests
 | Control Plane resource requests
+| 
 | RKE2_CONTROL_PLANE_RESOURCE_REQUESTS
 
 | control-plane-resource-limits
 | Control Plane resource limits
+| 
 | RKE2_CONTROL_PLANE_RESOURCE_LIMITS
 
 | control-plane-probe-configuration
 | Control Plane Probe configuration
+| 
 | RKE2_CONTROL_PLANE_PROBE_CONFIGURATION
 
 | kube-apiserver-extra-mount
 | kube-apiserver extra volume mounts
+| 
 | RKE2_KUBE_APISERVER_EXTRA_MOUNT
 
 | kube-scheduler-extra-mount
 | kube-scheduler extra volume mounts
+| 
 | RKE2_KUBE_SCHEDULER_EXTRA_MOUNT
 
 | kube-controller-manager-extra-mount
 | kube-controller-manager extra volume mounts
+| 
 | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_MOUNT
 
 | kube-proxy-extra-mount
 | kube-proxy extra volume mounts
+| 
 | RKE2_KUBE_PROXY_EXTRA_MOUNT
 
 | etcd-extra-mount
 | etcd extra volume mounts
+| 
 | RKE2_ETCD_EXTRA_MOUNT
 
 | cloud-controller-manager-extra-mount
 | cloud-controller-manager extra volume mounts
+| 
 | RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_MOUNT
 
 | kube-apiserver-extra-env
 | kube-apiserver extra environment variables
+| 
 | RKE2_KUBE_APISERVER_EXTRA_ENV
 
 | kube-scheduler-extra-env
 | kube-scheduler extra environment variables
+| 
 | RKE2_KUBE_SCHEDULER_EXTRA_ENV
 
 | kube-controller-manager-extra-env
 | kube-controller-manager extra environment variables
+| 
 | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_ENV
 
 | kube-proxy-extra-env
 | kube-proxy extra environment variables
+| 
 | RKE2_KUBE_PROXY_EXTRA_ENV
 
 | etcd-extra-env
 | etcd extra environment variables
+| 
 | RKE2_ETCD_EXTRA_ENV
 
 | cloud-controller-manager-extra-env
 | cloud-controller-manager extra environment variables
-| RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV
-
-| ingress-controller 
-| Ingress Controller to deploy one of, none, ingress-nginx, traefik  
 | 
+| RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV
 
 |===
 
@@ -440,20 +504,29 @@ The following options must be set to the same value on all servers in the cluste
 | etcd-image
 | Override image to use for etcd
 | RKE2_ETCD_IMAGE
+
 |===
 
 === Cloud Provider
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description | Default | Environment Variable
 
 | cloud-provider-name
 | Cloud provider name
+| 
 | RKE2_CLOUD_PROVIDER_NAME
 
 | cloud-provider-config
 | Cloud provider configuration file path
+| 
 | RKE2_CLOUD_PROVIDER_CONFIG
+
+| node-name-from-cloud-provider-metadata
+| Set node name from instance metadata service hostname
+| false
+| RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA
+
 |===
 
 === Security
@@ -462,7 +535,7 @@ The following options must be set to the same value on all servers in the cluste
 | Flag | Description | Environment Variable
 
 | profile
-| Validate system configuration against the selected benchmark (valid items: cis, cis-1.23 (deprecated))
+| Validate system configuration against the selected benchmark (valid items: cis, etcd)
 | RKE2_CIS_PROFILE
 
 | audit-policy-file
@@ -473,28 +546,33 @@ The following options must be set to the same value on all servers in the cluste
 | Path to the file that defines Pod Security Admission configuration
 | RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE
 
-| secrets-encryption-provider 
-| Encryption provider to use
-| N/A
-
 |===
 
 === Experimental
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description | Default | Environment Variable
 
-| embedded-registry
-| Enable embedded distributed container registry; requires use of embedded containerd
-|
+| supervisor-metrics
+| Enable serving rke2 internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port
+| false
+| 
 
 | enable-pprof
 | Enable pprof endpoint on supervisor port
-|
+| false
+| 
+
+| secrets-encryption-provider
+| Secret encryption provider (valid values: 'aescbc', 'secretbox')
+| "aescbc"
+| 
 
 | kubelet-path
 | Override kubelet binary path
+| 
 | RKE2_KUBELET_PATH
+
 |===
 
 === Agent/Node
@@ -504,48 +582,49 @@ The following options must be set to the same value on all servers in the cluste
 
 | node-name
 | Node name
-|
+| 
 | RKE2_NODE_NAME
 
 | with-node-id
 | Append id to node name
-|
-|
+| false
+| 
 
 | node-label
 | Registering and starting kubelet with set of labels
-|
-|
+| 
+| 
 
 | node-taint
 | Registering kubelet with set of taints
-|
-|
+| 
+| 
 
 | image-credential-provider-bin-dir
 | The path to the directory where credential provider plugin binaries are located
 | "/var/lib/rancher/credentialprovider/bin"
-|
+| 
 
 | image-credential-provider-config
 | The path to the credential provider plugin config file
 | "/var/lib/rancher/credentialprovider/config.yaml"
-|
+| 
 
 | protect-kernel-defaults
 | Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
-|
-|
+| false
+| 
 
 | selinux
 | Enable SELinux in containerd
-|
+| false
 | RKE2_SELINUX
 
 | lb-server-port
 | Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.
 | 6444
 | RKE2_LB_SERVER_PORT
+
 |===
 
 === Agent/Runtime
@@ -554,38 +633,45 @@ The following options must be set to the same value on all servers in the cluste
 | Flag | Description | Default | Environment Variable
 
 | container-runtime-endpoint
-| Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path
-|
-|
+| Disable embedded containerd and use the CRI socket at the given path
+| 
+| 
 
 | default-runtime
 | Set the default runtime in containerd
-|
-|
+| 
+| 
 
 | snapshotter
 | Override default containerd snapshotter
 | "overlayfs"
-|
+| 
 
 | private-registry
 | Private registry configuration file
 | "/etc/rancher/rke2/registries.yaml"
-|
+| 
 
 | system-default-registry
 | Private registry to be used for all system images
-|
+| 
 | RKE2_SYSTEM_DEFAULT_REGISTRY
+
 |===
 
 === Agent/Containerd
 
 |===
-| Flag | Description
+| Flag | Description | Default
 
 | disable-default-registry-endpoint
 | Disables containerd's fallback default registry endpoint when a mirror is configured for that registry
+| false
+
+| nonroot-devices
+| Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config
+| false
+
 |===
 
 === Agent/Networking
@@ -595,15 +681,24 @@ The following options must be set to the same value on all servers in the cluste
 
 | node-ip
 | IPv4/IPv6 addresses to advertise for node
-|
+| 
 
 | node-external-ip
 | IPv4/IPv6 external IP addresses to advertise for node
-|
+| 
+
+| node-internal-dns
+| internal DNS addresses to advertise for node
+| 
+
+| node-external-dns
+| external DNS addresses to advertise for node
+| 
 
 | resolv-conf
 | Kubelet resolv.conf file
 | RKE2_RESOLV_CONF
+
 |===
 
 === Agent/Flags
@@ -616,4 +711,6 @@ The following options must be set to the same value on all servers in the cluste
 
 | kube-proxy-arg
 | Customized flag for kube-proxy process
+
 |===
+

--- a/versions/latest/modules/zh/pages/reference/linux_agent_config.adoc
+++ b/versions/latest/modules/zh/pages/reference/linux_agent_config.adoc
@@ -1,76 +1,353 @@
-= Agent 配置参考
+= Agent Configuration Reference
 :page-languages: [en, zh]
-:revdate: 2024-09-11
+:revdate: 2026-06-19
 :page-revdate: {revdate}
 
-本文提供了可用于配置 RKE2 Agent 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_configuration_file[配置文件]。
+This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#configuration-file[configuration file].
 
-== RKE2 Agent CLI 帮助
+== Common
 
-[NOTE]
-====
-如果某个选项出现在括号中（例如 `[$RKE2_URL]`），该选项可以作为该名称的环境变量传入。
-====
+|===
+| Flag | Description | Default | Environment Variable
 
-[,console]
-----
-NAME:
-   rke2 agent - Run node agent
+| config
+| Path to config file
+| /etc/rancher/rke2/config.yaml
+| RKE2_CONFIG_FILE
 
-USAGE:
-   rke2 agent command [command options] [arguments...]
+| debug
+| Turn on debug logs
+| false
+| RKE2_DEBUG
 
-COMMANDS:
+| data-dir
+| Folder to hold state
+| "/var/lib/rancher/rke2"
+| RKE2_DATA_DIR
 
+|===
 
-OPTIONS:
-   --config FILE, -c FILE                        (config) Load configuration from FILE (default: "/etc/rancher/rke2/config.yaml") [$RKE2_CONFIG_FILE]
-   --debug                                       (logging) Turn on debug logs [$RKE2_DEBUG]
-   --token value, -t value                       (cluster) Token to use for authentication [$RKE2_TOKEN]
-   --token-file value                            (cluster) Token file to use for authentication [$RKE2_TOKEN_FILE]
-   --server value, -s value                      (cluster) Server to connect to [$RKE2_URL]
-   --data-dir value, -d value                    (data) Folder to hold state (default: "/var/lib/rancher/rke2")
-   --node-name value                             (agent/node) Node name [$RKE2_NODE_NAME]
-   --node-label value                            (agent/node) Registering and starting kubelet with set of labels
-   --node-taint value                            (agent/node) Registering kubelet with set of taints
-   --image-credential-provider-bin-dir value     (agent/node) The path to the directory where credential provider plugin binaries are located (default: "/var/lib/rancher/credentialprovider/bin")
-   --image-credential-provider-config value      (agent/node) The path to the credential provider plugin config file (default: "/var/lib/rancher/credentialprovider/config.yaml")
-   --container-runtime-endpoint value            (agent/runtime) Disable embedded containerd and use alternative CRI implementation
-   --snapshotter value                           (agent/runtime) Override default containerd snapshotter (default: "overlayfs")
-   --private-registry value                      (agent/runtime) Private registry configuration file (default: "/etc/rancher/rke2/registries.yaml")
-   --node-ip value, -i value                     (agent/networking) IPv4/IPv6 addresses to advertise for node
-   --node-external-ip value                      (agent/networking) IPv4/IPv6 external IP addresses to advertise for node
-   --resolv-conf value                           (agent/networking) Kubelet resolv.conf file [$RKE2_RESOLV_CONF]
-   --kubelet-arg value                           (agent/flags) Customized flag for kubelet process
-   --kube-proxy-arg value                        (agent/flags) Customized flag for kube-proxy process
-   --protect-kernel-defaults                     (agent/node) Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
-   --selinux                                     (agent/node) Enable SELinux in containerd [$RKE2_SELINUX]
-   --lb-server-port value                        (agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer. (default: 6444) [$RKE2_LB_SERVER_PORT]
-   --kube-apiserver-image value                  (image) Override image to use for kube-apiserver [$RKE2_KUBE_APISERVER_IMAGE]
-   --kube-controller-manager-image value         (image) Override image to use for kube-controller-manager [$RKE2_KUBE_CONTROLLER_MANAGER_IMAGE]
-   --kube-proxy-image value                      (image) Override image to use for kube-proxy [$RKE2_KUBE_PROXY_IMAGE]
-   --kube-scheduler-image value                  (image) Override image to use for kube-scheduler [$RKE2_KUBE_SCHEDULER_IMAGE]
-   --pause-image value                           (image) Override image to use for pause [$RKE2_PAUSE_IMAGE]
-   --runtime-image value                         (image) Override image to use for runtime binaries (containerd, kubectl, crictl, etc) [$RKE2_RUNTIME_IMAGE]
-   --etcd-image value                            (image) Override image to use for etcd [$RKE2_ETCD_IMAGE]
-   --kubelet-path value                          (experimental/agent) Override kubelet binary path [$RKE2_KUBELET_PATH]
-   --cloud-provider-name value                   (cloud provider) Cloud provider name [$RKE2_CLOUD_PROVIDER_NAME]
-   --cloud-provider-config value                 (cloud provider) Cloud provider configuration file path [$RKE2_CLOUD_PROVIDER_CONFIG]
-   --profile value                               (security) Validate system configuration against the selected benchmark (valid items: cis-1.6, cis-1.23 ) [$RKE2_CIS_PROFILE]
-   --audit-policy-file value                     (security) Path to the file that defines the audit policy configuration [$RKE2_AUDIT_POLICY_FILE]
-   --control-plane-resource-requests value       (components) Control Plane resource requests [$RKE2_CONTROL_PLANE_RESOURCE_REQUESTS]
-   --control-plane-resource-limits value         (components) Control Plane resource limits [$RKE2_CONTROL_PLANE_RESOURCE_LIMITS]
-   --kube-apiserver-extra-mount value            (components) kube-apiserver extra volume mounts [$RKE2_KUBE_APISERVER_EXTRA_MOUNT]
-   --kube-scheduler-extra-mount value            (components) kube-scheduler extra volume mounts [$RKE2_KUBE_SCHEDULER_EXTRA_MOUNT]
-   --kube-controller-manager-extra-mount value   (components) kube-controller-manager extra volume mounts [$RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_MOUNT]
-   --kube-proxy-extra-mount value                (components) kube-proxy extra volume mounts [$RKE2_KUBE_PROXY_EXTRA_MOUNT]
-   --etcd-extra-mount value                      (components) etcd extra volume mounts [$RKE2_ETCD_EXTRA_MOUNT]
-   --cloud-controller-manager-extra-mount value  (components) cloud-controller-manager extra volume mounts [$RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_MOUNT]
-   --kube-apiserver-extra-env value              (components) kube-apiserver extra environment variables [$RKE2_KUBE_APISERVER_EXTRA_ENV]
-   --kube-scheduler-extra-env value              (components) kube-scheduler extra environment variables [$RKE2_KUBE_SCHEDULER_EXTRA_ENV]
-   --kube-controller-manager-extra-env value     (components) kube-controller-manager extra environment variables [$RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_ENV]
-   --kube-proxy-extra-env value                  (components) kube-proxy extra environment variables [$RKE2_KUBE_PROXY_EXTRA_ENV]
-   --etcd-extra-env value                        (components) etcd extra environment variables [$RKE2_ETCD_EXTRA_ENV]
-   --cloud-controller-manager-extra-env value    (components) cloud-controller-manager extra environment variables [$RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV]
-   --help, -h                                    show help
-----
+== Cluster
+
+|===
+| Flag | Description | Environment Variable
+
+| token
+| Token to use for authentication
+| RKE2_TOKEN
+
+| token-file
+| Token file to use for authentication
+| RKE2_TOKEN_FILE
+
+| server
+| Server to connect to
+| RKE2_URL
+
+|===
+
+== Listener
+
+|===
+| Flag | Description | Default
+
+| bind-address
+| rke2 bind address
+| 0.0.0.0
+
+|===
+
+== Image
+
+|===
+| Flag | Description | Environment Variable
+
+| kube-apiserver-image
+| Override image to use for kube-apiserver
+| RKE2_KUBE_APISERVER_IMAGE
+
+| kube-controller-manager-image
+| Override image to use for kube-controller-manager
+| RKE2_KUBE_CONTROLLER_MANAGER_IMAGE
+
+| cloud-controller-manager-image
+| Override image to use for cloud-controller-manager
+| RKE2_CLOUD_CONTROLLER_MANAGER_IMAGE
+
+| kube-proxy-image
+| Override image to use for kube-proxy
+| RKE2_KUBE_PROXY_IMAGE
+
+| kube-scheduler-image
+| Override image to use for kube-scheduler
+| RKE2_KUBE_SCHEDULER_IMAGE
+
+| pause-image
+| Override image to use for pause
+| RKE2_PAUSE_IMAGE
+
+| runtime-image
+| Override image to use for runtime binaries (containerd, kubectl, crictl, etc)
+| RKE2_RUNTIME_IMAGE
+
+| etcd-image
+| Override image to use for etcd
+| RKE2_ETCD_IMAGE
+
+|===
+
+== Cloud Provider
+
+|===
+| Flag | Description | Default | Environment Variable
+
+| cloud-provider-name
+| Cloud provider name
+| 
+| RKE2_CLOUD_PROVIDER_NAME
+
+| cloud-provider-config
+| Cloud provider configuration file path
+| 
+| RKE2_CLOUD_PROVIDER_CONFIG
+
+| node-name-from-cloud-provider-metadata
+| Set node name from instance metadata service hostname
+| false
+| RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA
+
+|===
+
+== Security
+
+|===
+| Flag | Description | Environment Variable
+
+| profile
+| Validate system configuration against the selected benchmark (valid items: cis, etcd)
+| RKE2_CIS_PROFILE
+
+| audit-policy-file
+| Path to the file that defines the audit policy configuration
+| RKE2_AUDIT_POLICY_FILE
+
+| pod-security-admission-config-file
+| Path to the file that defines Pod Security Admission configuration
+| RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE
+
+|===
+
+== Components
+
+|===
+| Flag | Description | Environment Variable
+
+| control-plane-resource-requests
+| Control Plane resource requests
+| RKE2_CONTROL_PLANE_RESOURCE_REQUESTS
+
+| control-plane-resource-limits
+| Control Plane resource limits
+| RKE2_CONTROL_PLANE_RESOURCE_LIMITS
+
+| control-plane-probe-configuration
+| Control Plane Probe configuration
+| RKE2_CONTROL_PLANE_PROBE_CONFIGURATION
+
+| kube-apiserver-extra-mount
+| kube-apiserver extra volume mounts
+| RKE2_KUBE_APISERVER_EXTRA_MOUNT
+
+| kube-scheduler-extra-mount
+| kube-scheduler extra volume mounts
+| RKE2_KUBE_SCHEDULER_EXTRA_MOUNT
+
+| kube-controller-manager-extra-mount
+| kube-controller-manager extra volume mounts
+| RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_MOUNT
+
+| kube-proxy-extra-mount
+| kube-proxy extra volume mounts
+| RKE2_KUBE_PROXY_EXTRA_MOUNT
+
+| etcd-extra-mount
+| etcd extra volume mounts
+| RKE2_ETCD_EXTRA_MOUNT
+
+| cloud-controller-manager-extra-mount
+| cloud-controller-manager extra volume mounts
+| RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_MOUNT
+
+| kube-apiserver-extra-env
+| kube-apiserver extra environment variables
+| RKE2_KUBE_APISERVER_EXTRA_ENV
+
+| kube-scheduler-extra-env
+| kube-scheduler extra environment variables
+| RKE2_KUBE_SCHEDULER_EXTRA_ENV
+
+| kube-controller-manager-extra-env
+| kube-controller-manager extra environment variables
+| RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_ENV
+
+| kube-proxy-extra-env
+| kube-proxy extra environment variables
+| RKE2_KUBE_PROXY_EXTRA_ENV
+
+| etcd-extra-env
+| etcd extra environment variables
+| RKE2_ETCD_EXTRA_ENV
+
+| cloud-controller-manager-extra-env
+| cloud-controller-manager extra environment variables
+| RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV
+
+|===
+
+== Node
+
+|===
+| Flag | Description | Default | Environment Variable
+
+| node-name
+| Node name
+| 
+| RKE2_NODE_NAME
+
+| with-node-id
+| Append id to node name
+| false
+| 
+
+| node-label
+| Registering and starting kubelet with set of labels
+| 
+| 
+
+| node-taint
+| Registering kubelet with set of taints
+| 
+| 
+
+| image-credential-provider-bin-dir
+| The path to the directory where credential provider plugin binaries are located
+| "/var/lib/rancher/credentialprovider/bin"
+| 
+
+| image-credential-provider-config
+| The path to the credential provider plugin config file
+| "/var/lib/rancher/credentialprovider/config.yaml"
+| 
+
+| selinux
+| Enable SELinux in containerd
+| false
+| RKE2_SELINUX
+
+| lb-server-port
+| Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.
+| 6444
+| RKE2_LB_SERVER_PORT
+
+| protect-kernel-defaults
+| Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
+| false
+| 
+
+|===
+
+== Runtime
+
+|===
+| Flag | Description | Default
+
+| container-runtime-endpoint
+| Disable embedded containerd and use the CRI socket at the given path
+| 
+
+| default-runtime
+| Set the default runtime in containerd
+| 
+
+| snapshotter
+| Override default containerd snapshotter
+| "overlayfs"
+
+| private-registry
+| Private registry configuration file
+| "/etc/rancher/rke2/registries.yaml"
+
+|===
+
+== Containerd
+
+|===
+| Flag | Description | Default
+
+| disable-default-registry-endpoint
+| Disables containerd's fallback default registry endpoint when a mirror is configured for that registry
+| false
+
+| nonroot-devices
+| Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config
+| false
+
+|===
+
+== Networking
+
+|===
+| Flag | Description | Environment Variable
+
+| node-ip
+| IPv4/IPv6 addresses to advertise for node
+| 
+
+| node-external-ip
+| IPv4/IPv6 external IP addresses to advertise for node
+| 
+
+| node-internal-dns
+| internal DNS addresses to advertise for node
+| 
+
+| node-external-dns
+| external DNS addresses to advertise for node
+| 
+
+| resolv-conf
+| Kubelet resolv.conf file
+| RKE2_RESOLV_CONF
+
+|===
+
+== Flags
+
+|===
+| Flag | Description
+
+| kubelet-arg
+| Customized flag for kubelet process
+
+| kube-proxy-arg
+| Customized flag for kube-proxy process
+
+|===
+
+== Experimental
+
+|===
+| Flag | Description | Default | Environment Variable
+
+| enable-pprof
+| Enable pprof endpoint on supervisor port
+| false
+| 
+
+| kubelet-path
+| Override kubelet binary path
+| 
+| RKE2_KUBELET_PATH
+
+|===
+

--- a/versions/latest/modules/zh/pages/reference/linux_agent_config.adoc
+++ b/versions/latest/modules/zh/pages/reference/linux_agent_config.adoc
@@ -3,7 +3,7 @@
 :revdate: 2026-06-19
 :page-revdate: {revdate}
 
-This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#configuration-file[configuration file].
+This is a reference to all parameters that can be used to configure the rke2 agent. Note that while this is a reference to the command line arguments, the best way to configure RKE2 is using the xref:install/configuration.adoc#_configuration_file[configuration file].
 
 == Common
 

--- a/versions/latest/modules/zh/pages/reference/server_config.adoc
+++ b/versions/latest/modules/zh/pages/reference/server_config.adoc
@@ -3,9 +3,9 @@
 :revdate: 2026-06-19
 :page-revdate: {revdate}
 
-本文提供了可用于配置 RKE2 Server 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#configuration-file[配置文件]。
+本文提供了可用于配置 RKE2 Server 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_configuration_file[配置文件]。
 
-=== Critical Configuration Values
+==Critical Configuration Values
 
 The following options must be set to the same value on all servers in the cluster. Failure to do so will cause new servers to fail to join the cluster.
 
@@ -18,7 +18,7 @@ The following options must be set to the same value on all servers in the cluste
 * `egress-selector-mode`
 * `service-cidr`
 
-=== Common
+==Common
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -40,7 +40,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Listener
+==Listener
 
 |===
 | Flag | Description | Default
@@ -63,7 +63,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Networking
+==Networking
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -115,7 +115,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Client
+==Client
 
 |===
 | Flag | Description | Environment Variable
@@ -134,7 +134,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Helm
+==Helm
 
 |===
 | Flag | Description
@@ -144,7 +144,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Cluster
+==Cluster
 
 |===
 | Flag | Description | Environment Variable
@@ -175,7 +175,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Database
+==Database
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -247,7 +247,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== S3 etcd Snapshot Storage
+==S3 etcd Snapshot Storage
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -334,7 +334,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Flags
+==Flags
 
 |===
 | Flag | Description
@@ -356,7 +356,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Components
+==Components
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -468,7 +468,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Image
+==Image
 
 |===
 | Flag | Description | Environment Variable
@@ -507,7 +507,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Cloud Provider
+==Cloud Provider
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -529,7 +529,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Security
+==Security
 
 |===
 | Flag | Description | Environment Variable
@@ -548,7 +548,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Experimental
+==Experimental
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -575,7 +575,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Node
+==Agent/Node
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -627,7 +627,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Runtime
+==Agent/Runtime
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -659,7 +659,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Containerd
+==Agent/Containerd
 
 |===
 | Flag | Description | Default
@@ -674,7 +674,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Networking
+==Agent/Networking
 
 |===
 | Flag | Description | Environment Variable
@@ -701,7 +701,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-=== Agent/Flags
+==Agent/Flags
 
 |===
 | Flag | Description

--- a/versions/latest/modules/zh/pages/reference/server_config.adoc
+++ b/versions/latest/modules/zh/pages/reference/server_config.adoc
@@ -5,7 +5,7 @@
 
 本文提供了可用于配置 RKE2 Server 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_configuration_file[配置文件]。
 
-==Critical Configuration Values
+== Critical Configuration Values
 
 The following options must be set to the same value on all servers in the cluster. Failure to do so will cause new servers to fail to join the cluster.
 
@@ -18,7 +18,7 @@ The following options must be set to the same value on all servers in the cluste
 * `egress-selector-mode`
 * `service-cidr`
 
-==Common
+== Common
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -40,7 +40,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Listener
+== Listener
 
 |===
 | Flag | Description | Default
@@ -63,7 +63,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Networking
+== Networking
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -115,7 +115,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Client
+== Client
 
 |===
 | Flag | Description | Environment Variable
@@ -134,7 +134,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Helm
+== Helm
 
 |===
 | Flag | Description
@@ -144,7 +144,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Cluster
+== Cluster
 
 |===
 | Flag | Description | Environment Variable
@@ -175,7 +175,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Database
+== Database
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -247,7 +247,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==S3 etcd Snapshot Storage
+== S3 etcd Snapshot Storage
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -334,7 +334,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Flags
+== Flags
 
 |===
 | Flag | Description
@@ -356,7 +356,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Components
+== Components
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -468,7 +468,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Image
+== Image
 
 |===
 | Flag | Description | Environment Variable
@@ -507,7 +507,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Cloud Provider
+== Cloud Provider
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -529,7 +529,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Security
+== Security
 
 |===
 | Flag | Description | Environment Variable
@@ -548,7 +548,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Experimental
+== Experimental
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -575,7 +575,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Node
+== Agent/Node
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -627,7 +627,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Runtime
+== Agent/Runtime
 
 |===
 | Flag | Description | Default | Environment Variable
@@ -659,7 +659,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Containerd
+== Agent/Containerd
 
 |===
 | Flag | Description | Default
@@ -674,7 +674,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Networking
+== Agent/Networking
 
 |===
 | Flag | Description | Environment Variable
@@ -701,7 +701,7 @@ The following options must be set to the same value on all servers in the cluste
 
 |===
 
-==Agent/Flags
+== Agent/Flags
 
 |===
 | Flag | Description

--- a/versions/latest/modules/zh/pages/reference/server_config.adoc
+++ b/versions/latest/modules/zh/pages/reference/server_config.adoc
@@ -1,11 +1,11 @@
 = Server 配置参考
 :page-languages: [en, zh]
-:revdate: 2026-04-01
+:revdate: 2026-06-19
 :page-revdate: {revdate}
 
-本文提供了可用于配置 RKE2 Server 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#_configuration_file[配置文件]。
+本文提供了可用于配置 RKE2 Server 的所有参数的参考。请注意，这些内容引用了命令行参数，但配置 RKE2 的最佳方法是使用xref:install/configuration.adoc#configuration-file[配置文件]。
 
-== Critical Configuration Values
+=== Critical Configuration Values
 
 The following options must be set to the same value on all servers in the cluster. Failure to do so will cause new servers to fail to join the cluster.
 
@@ -30,13 +30,14 @@ The following options must be set to the same value on all servers in the cluste
 
 | debug
 | Turn on debug logs
-|
+| false
 | RKE2_DEBUG
 
 | data-dir
 | Folder to hold state
 | "/var/lib/rancher/rke2"
-|
+| RKE2_DATA_DIR
+
 |===
 
 === Listener
@@ -54,11 +55,12 @@ The following options must be set to the same value on all servers in the cluste
 
 | tls-san
 | Add additional hostnames or IPv4/IPv6 addresses as Subject Alternative Names on the server TLS cert
-|
+| 
 
 | tls-san-security
 | Protect the server TLS cert by refusing to add Subject Alternative Names not associated with the kubernetes apiserver service, server nodes, or values of the tls-san option
 | true
+
 |===
 
 === Networking
@@ -69,42 +71,48 @@ The following options must be set to the same value on all servers in the cluste
 | cluster-cidr
 | IPv4/IPv6 network CIDRs to use for pod IPs
 | 10.42.0.0/16
-|
+| 
 
 | service-cidr
 | IPv4/IPv6 network CIDRs to use for service IPs
 | 10.43.0.0/16
-|
+| 
 
 | service-node-port-range
 | Port range to reserve for services with NodePort visibility
 | "30000-32767"
-|
+| 
 
 | cluster-dns
-| IPv4 Cluster IP for coredns service. Should be in your service-cidr range
+| IPv4/IPv6 Cluster IP for coredns service. Should be in your service-cidr range
 | 10.43.0.10
-|
+| 
 
 | cluster-domain
 | Cluster Domain
 | "cluster.local"
-|
+| 
 
 | egress-selector-mode
 | One of 'agent', 'cluster', 'pod', 'disabled'
 | "agent"
-|
+| 
 
 | servicelb-namespace
 | Namespace of the pods for the servicelb component
 | "kube-system"
-|
+| 
 
 | cni
-| CNI Plugins to deploy, one of none, calico, canal, cilium; optionally with multus as the first value to enable the multus meta-plugin
-| canal
+| CNI Plugins to deploy, one of none, calico, canal, cilium, flannel; optionally with multus as the first value to enable the multus meta-plugin
+| "canal"
 | RKE2_CNI
+
+| ingress-controller
+| Ingress Controllers to deploy, one of none, traefik, ingress-nginx; the first value will be set as the default ingress class
+| 
+| RKE2_INGRESS_CONTROLLER
+
 |===
 
 === Client
@@ -119,6 +127,11 @@ The following options must be set to the same value on all servers in the cluste
 | write-kubeconfig-mode
 | Write kubeconfig with this mode
 | RKE2_KUBECONFIG_MODE
+
+| write-kubeconfig-group
+| Write kubeconfig with this group
+| RKE2_KUBECONFIG_GROUP
+
 |===
 
 === Helm
@@ -128,6 +141,7 @@ The following options must be set to the same value on all servers in the cluste
 
 | helm-job-image
 | Default image to use for helm jobs
+
 |===
 
 === Cluster
@@ -158,6 +172,7 @@ The following options must be set to the same value on all servers in the cluste
 | cluster-reset
 | Forget all peers and become sole member of a new cluster
 | RKE2_CLUSTER_RESET
+
 |===
 
 === Database
@@ -167,43 +182,69 @@ The following options must be set to the same value on all servers in the cluste
 
 | cluster-reset-restore-path
 | Path to snapshot file to be restored
-|
-|
+| 
+| 
+
+| datastore-endpoint
+| Specify etcd, NATS, MySQL, Postgres, or SQLite  data source name
+| sqlite
+| RKE2_DATASTORE_ENDPOINT
+
+| datastore-cafile
+| TLS Certificate Authority file used to secure datastore backend communication
+| 
+| RKE2_DATASTORE_CAFILE
+
+| datastore-certfile
+| TLS certification file used to secure datastore backend communication
+| 
+| RKE2_DATASTORE_CERTFILE
+
+| datastore-keyfile
+| TLS key file used to secure datastore backend communication
+| 
+| RKE2_DATASTORE_KEYFILE
 
 | etcd-expose-metrics
-| Expose etcd metrics to client interface.
+| Expose etcd metrics to client interface
 | false
-|
+| 
 
 | etcd-disable-snapshots
 | Disable automatic etcd snapshots
-|
-|
+| false
+| 
 
 | etcd-snapshot-name
-| Set the base name of etcd snapshots
-| etcd-snapshot-<unix-timestamp>)
-|
+| Set the base name of etcd snapshots, appended with UNIX timestamp
+| "etcd-snapshot"
+| 
 
 | etcd-snapshot-schedule-cron
 | Snapshot interval time in cron spec. eg. every 5 hours '0 */5 * * *'
 | "0 */12 * * *"
-|
+| 
+
+| etcd-snapshot-reconcile-interval
+| Snapshot reconcile interval
+| 10m0s
+| 
 
 | etcd-snapshot-retention
 | Number of snapshots to retain
 | 5
-|
+| 
 
 | etcd-snapshot-dir
 | Directory to save db snapshots.
-| $&#123;data-dir&#125;/db/snapshots
-|
+| $&#123;data-dir&#125;/server/db/snapshots
+| 
 
 | etcd-snapshot-compress
 | Compress etcd snapshot
-|
-|
+| false
+| 
+
 |===
 
 === S3 etcd Snapshot Storage
@@ -213,7 +254,7 @@ The following options must be set to the same value on all servers in the cluste
 
 | etcd-s3
 | Enable backup to S3
-| 
+| false
 | 
 
 | etcd-s3-endpoint
@@ -228,7 +269,7 @@ The following options must be set to the same value on all servers in the cluste
 
 | etcd-s3-skip-ssl-verify
 | Disables S3 SSL certificate validation
-| 
+| false
 | 
 
 | etcd-s3-access-key
@@ -252,8 +293,8 @@ The following options must be set to the same value on all servers in the cluste
 | 
 
 | etcd-s3-bucket-lookup-type
-| S3 bucket lookup type, one of 'auto', 'dns', 'path'
-| "auto"
+| S3 bucket lookup type, one of 'auto', 'dns', 'path'; default is 'auto' if not set
+| 
 | 
 
 | etcd-s3-region
@@ -283,13 +324,14 @@ The following options must be set to the same value on all servers in the cluste
 
 | etcd-s3-insecure
 | Disables S3 over HTTPS
-| 
+| false
 | 
 
 | etcd-s3-timeout
 | S3 timeout
 | 5m0s
 | 
+
 |===
 
 === Flags
@@ -311,96 +353,118 @@ The following options must be set to the same value on all servers in the cluste
 
 | kube-cloud-controller-manager-arg
 | Customized flag for kube-cloud-controller-manager process
+
 |===
 
 === Components
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description | Default | Environment Variable
 
 | disable
-| Do not deploy packaged components and delete any deployed components (valid items: rke2-coredns, rke2-ingress-nginx, rke2-metrics-server)
-|
+| Do not deploy packaged components and delete any deployed components (valid items: rke2-coredns, rke2-metrics-server, rke2-snapshot-controller, rke2-snapshot-controller-crd, rke2-snapshot-validation-webhook)
+| 
+| 
 
 | disable-scheduler
 | Disable Kubernetes default scheduler
-|
+| false
+| 
 
 | disable-cloud-controller
 | Disable rke2 default cloud controller manager
-|
+| false
+| 
 
 | disable-kube-proxy
 | Disable running kube-proxy
-|
+| false
+| 
+
+| embedded-registry
+| Enable embedded distributed container registry; requires use of embedded containerd; when enabled agents will also listen on the supervisor port
+| false
+| 
 
 | enable-servicelb
 | Enable rke2 default cloud controller manager's service controller
+| false
 | RKE2_ENABLE_SERVICELB
 
 | control-plane-resource-requests
 | Control Plane resource requests
+| 
 | RKE2_CONTROL_PLANE_RESOURCE_REQUESTS
 
 | control-plane-resource-limits
 | Control Plane resource limits
+| 
 | RKE2_CONTROL_PLANE_RESOURCE_LIMITS
 
 | control-plane-probe-configuration
 | Control Plane Probe configuration
+| 
 | RKE2_CONTROL_PLANE_PROBE_CONFIGURATION
 
 | kube-apiserver-extra-mount
 | kube-apiserver extra volume mounts
+| 
 | RKE2_KUBE_APISERVER_EXTRA_MOUNT
 
 | kube-scheduler-extra-mount
 | kube-scheduler extra volume mounts
+| 
 | RKE2_KUBE_SCHEDULER_EXTRA_MOUNT
 
 | kube-controller-manager-extra-mount
 | kube-controller-manager extra volume mounts
+| 
 | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_MOUNT
 
 | kube-proxy-extra-mount
 | kube-proxy extra volume mounts
+| 
 | RKE2_KUBE_PROXY_EXTRA_MOUNT
 
 | etcd-extra-mount
 | etcd extra volume mounts
+| 
 | RKE2_ETCD_EXTRA_MOUNT
 
 | cloud-controller-manager-extra-mount
 | cloud-controller-manager extra volume mounts
+| 
 | RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_MOUNT
 
 | kube-apiserver-extra-env
 | kube-apiserver extra environment variables
+| 
 | RKE2_KUBE_APISERVER_EXTRA_ENV
 
 | kube-scheduler-extra-env
 | kube-scheduler extra environment variables
+| 
 | RKE2_KUBE_SCHEDULER_EXTRA_ENV
 
 | kube-controller-manager-extra-env
 | kube-controller-manager extra environment variables
+| 
 | RKE2_KUBE_CONTROLLER_MANAGER_EXTRA_ENV
 
 | kube-proxy-extra-env
 | kube-proxy extra environment variables
+| 
 | RKE2_KUBE_PROXY_EXTRA_ENV
 
 | etcd-extra-env
 | etcd extra environment variables
+| 
 | RKE2_ETCD_EXTRA_ENV
 
 | cloud-controller-manager-extra-env
 | cloud-controller-manager extra environment variables
-| RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV
-
-| ingress-controller 
-| Ingress Controller to deploy one of, none, ingress-nginx, traefik  
 | 
+| RKE2_CLOUD_CONTROLLER_MANAGER_EXTRA_ENV
 
 |===
 
@@ -440,20 +504,29 @@ The following options must be set to the same value on all servers in the cluste
 | etcd-image
 | Override image to use for etcd
 | RKE2_ETCD_IMAGE
+
 |===
 
 === Cloud Provider
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description | Default | Environment Variable
 
 | cloud-provider-name
 | Cloud provider name
+| 
 | RKE2_CLOUD_PROVIDER_NAME
 
 | cloud-provider-config
 | Cloud provider configuration file path
+| 
 | RKE2_CLOUD_PROVIDER_CONFIG
+
+| node-name-from-cloud-provider-metadata
+| Set node name from instance metadata service hostname
+| false
+| RKE2_NODE_NAME_FROM_CLOUD_PROVIDER_METADATA
+
 |===
 
 === Security
@@ -462,7 +535,7 @@ The following options must be set to the same value on all servers in the cluste
 | Flag | Description | Environment Variable
 
 | profile
-| Validate system configuration against the selected benchmark (valid items: cis, cis-1.23 (deprecated))
+| Validate system configuration against the selected benchmark (valid items: cis, etcd)
 | RKE2_CIS_PROFILE
 
 | audit-policy-file
@@ -473,28 +546,33 @@ The following options must be set to the same value on all servers in the cluste
 | Path to the file that defines Pod Security Admission configuration
 | RKE2_POD_SECURITY_ADMISSION_CONFIG_FILE
 
-| secrets-encryption-provider 
-| Encryption provider to use
-| N/A
-
 |===
 
 === Experimental
 
 |===
-| Flag | Description | Environment Variable
+| Flag | Description | Default | Environment Variable
 
-| embedded-registry
-| Enable embedded distributed container registry; requires use of embedded containerd
-|
+| supervisor-metrics
+| Enable serving rke2 internal metrics on the supervisor port; when enabled agents will also listen on the supervisor port
+| false
+| 
 
 | enable-pprof
 | Enable pprof endpoint on supervisor port
-|
+| false
+| 
+
+| secrets-encryption-provider
+| Secret encryption provider (valid values: 'aescbc', 'secretbox')
+| "aescbc"
+| 
 
 | kubelet-path
 | Override kubelet binary path
+| 
 | RKE2_KUBELET_PATH
+
 |===
 
 === Agent/Node
@@ -504,48 +582,49 @@ The following options must be set to the same value on all servers in the cluste
 
 | node-name
 | Node name
-|
+| 
 | RKE2_NODE_NAME
 
 | with-node-id
 | Append id to node name
-|
-|
+| false
+| 
 
 | node-label
 | Registering and starting kubelet with set of labels
-|
-|
+| 
+| 
 
 | node-taint
 | Registering kubelet with set of taints
-|
-|
+| 
+| 
 
 | image-credential-provider-bin-dir
 | The path to the directory where credential provider plugin binaries are located
 | "/var/lib/rancher/credentialprovider/bin"
-|
+| 
 
 | image-credential-provider-config
 | The path to the credential provider plugin config file
 | "/var/lib/rancher/credentialprovider/config.yaml"
-|
+| 
 
 | protect-kernel-defaults
 | Kernel tuning behavior. If set, error if kernel tunables are different than kubelet defaults.
-|
-|
+| false
+| 
 
 | selinux
 | Enable SELinux in containerd
-|
+| false
 | RKE2_SELINUX
 
 | lb-server-port
 | Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.
 | 6444
 | RKE2_LB_SERVER_PORT
+
 |===
 
 === Agent/Runtime
@@ -554,38 +633,45 @@ The following options must be set to the same value on all servers in the cluste
 | Flag | Description | Default | Environment Variable
 
 | container-runtime-endpoint
-| Disable embedded containerd and use the CRI socket at the given path; when used with --docker this sets the docker socket path
-|
-|
+| Disable embedded containerd and use the CRI socket at the given path
+| 
+| 
 
 | default-runtime
 | Set the default runtime in containerd
-|
-|
+| 
+| 
 
 | snapshotter
 | Override default containerd snapshotter
 | "overlayfs"
-|
+| 
 
 | private-registry
 | Private registry configuration file
 | "/etc/rancher/rke2/registries.yaml"
-|
+| 
 
 | system-default-registry
 | Private registry to be used for all system images
-|
+| 
 | RKE2_SYSTEM_DEFAULT_REGISTRY
+
 |===
 
 === Agent/Containerd
 
 |===
-| Flag | Description
+| Flag | Description | Default
 
 | disable-default-registry-endpoint
 | Disables containerd's fallback default registry endpoint when a mirror is configured for that registry
+| false
+
+| nonroot-devices
+| Allows non-root pods to access devices by setting device_ownership_from_security_context=true in the containerd CRI config
+| false
+
 |===
 
 === Agent/Networking
@@ -595,15 +681,24 @@ The following options must be set to the same value on all servers in the cluste
 
 | node-ip
 | IPv4/IPv6 addresses to advertise for node
-|
+| 
 
 | node-external-ip
 | IPv4/IPv6 external IP addresses to advertise for node
-|
+| 
+
+| node-internal-dns
+| internal DNS addresses to advertise for node
+| 
+
+| node-external-dns
+| external DNS addresses to advertise for node
+| 
 
 | resolv-conf
 | Kubelet resolv.conf file
 | RKE2_RESOLV_CONF
+
 |===
 
 === Agent/Flags
@@ -616,4 +711,6 @@ The following options must be set to the same value on all servers in the cluste
 
 | kube-proxy-arg
 | Customized flag for kube-proxy process
+
 |===
+


### PR DESCRIPTION
Synced from rke2-docs commit ca9c89f: https://github.com/rancher/rke2-docs/pull/571

Major updates include:
- Reorganized sections for better clarity
- Added default values for many parameters
- Added missing environment variables (e.g., RKE2_DATA_DIR)
- Added new parameters:
  * node-internal-dns, node-external-dns (networking)
  * nonroot-devices (containerd)
  * embedded-registry (components)
  * supervisor-metrics (experimental)
  * write-kubeconfig-group (client)
  * ingress-controller (networking)
  * datastore-* parameters (database)
- Updated CIS profile valid items from "cis, cis-1.23" to "cis, etcd"
- Updated CNI options to include "flannel"
- Updated disable component list