### PR TITLE
[Sync rke2 docs] windows airgap

### DIFF
--- a/versions/latest/modules/en/pages/install/windows_airgap.adoc
+++ b/versions/latest/modules/en/pages/install/windows_airgap.adoc
@@ -1,6 +1,6 @@
 = Windows Air-Gap Install
 :page-languages: [en, zh]
-:revdate: 2025-08-06
+:revdate: 2026-06-19
 :page-revdate: {revdate}
 
 *Windows Support requires using Calico or Flannel as the CNI for the RKE2 cluster.*
@@ -92,8 +92,6 @@ Invoke-WebRequest <PRIME-Artifacts-URL>/rke2/<VERSION>/rke2-windows-1809-amd64-i
 $ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest <PRIME-Artifacts-URL>/rke2/<VERSION>/rke2-windows-ltsc2022-amd64-images.tar.zst -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-ltsc2022-amd64-images.tar.zst
 ----
-+
-** Use `rke2-windows-<VERSION>-amd64.tar.gz` or `rke2-windows-<VERSION>-amd64.tar.zst`. Zstandard offers better compression ratios and faster decompression speeds compared to pigz.
 +
 . Ensure that the `/var/lib/rancher/rke2/agent/images/` directory exists on the node.
 +

--- a/versions/latest/modules/zh/pages/install/windows_airgap.adoc
+++ b/versions/latest/modules/zh/pages/install/windows_airgap.adoc
@@ -1,6 +1,6 @@
 = Windows 离线安装
 :page-languages: [en, zh]
-:revdate: 2025-06-18
+:revdate: 2026-06-19
 :page-revdate: {revdate}
 
 *Windows Support requires using Calico or Flannel as the CNI for the RKE2 cluster.*
@@ -92,8 +92,6 @@ Invoke-WebRequest <PRIME-Artifacts-URL>/rke2/<VERSION>/rke2-windows-1809-amd64-i
 $ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest <PRIME-Artifacts-URL>/rke2/<VERSION>/rke2-windows-ltsc2022-amd64-images.tar.zst -OutFile c:/var/lib/rancher/rke2/agent/images/rke2-windows-ltsc2022-amd64-images.tar.zst
 ----
-+
-** Use `rke2-windows-<VERSION>-amd64.tar.gz` or `rke2-windows-<VERSION>-amd64.tar.zst`. Zstandard offers better compression ratios and faster decompression speeds compared to pigz.
 +
 . Ensure that the `/var/lib/rancher/rke2/agent/images/` directory exists on the node.
 +


### PR DESCRIPTION
This commit syncs changes from rke2-docs that clean up the Windows Air-Gap installation documentation by removing a redundant note about tar.gz vs tar.zst image tarballs. The information about Zstandard offering better compression is already mentioned earlier in the document (line 78 in the English version).

Changes:
- Removed duplicate note about rke2-windows-<VERSION> tar formats
- Updated revdate to 2026-06-19 for both en and zh versions

Related PR: https://github.com/rancher/rke2-docs/pull/574