### PR TITLE
[sync rke2-docs] Update GPU Operator version to v26.3.2

### DIFF
--- a/versions/latest/modules/en/pages/add-ons/gpu_operators.adoc
+++ b/versions/latest/modules/en/pages/add-ons/gpu_operators.adoc
@@ -154,7 +154,7 @@ metadata:
 spec:
   repo: https://helm.ngc.nvidia.com/nvidia
   chart: gpu-operator
-  version: v26.3.1
+  version: v26.3.2
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-
@@ -174,7 +174,7 @@ metadata:
 spec:
   repo: https://helm.ngc.nvidia.com/nvidia
   chart: gpu-operator
-  version: v26.3.1
+  version: v26.3.2
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-

--- a/versions/latest/modules/zh/pages/add-ons/gpu_operators.adoc
+++ b/versions/latest/modules/zh/pages/add-ons/gpu_operators.adoc
@@ -154,7 +154,7 @@ metadata:
 spec:
   repo: https://helm.ngc.nvidia.com/nvidia
   chart: gpu-operator
-  version: v26.3.1
+  version: v26.3.2
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-
@@ -174,7 +174,7 @@ metadata:
 spec:
   repo: https://helm.ngc.nvidia.com/nvidia
   chart: gpu-operator
-  version: v26.3.1
+  version: v26.3.2
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-


### PR DESCRIPTION
Update the NVIDIA GPU Operator chart version from v26.3.1 to v26.3.2 in both English and Chinese documentation.

This change updates the Helm chart version used in the GPU operator deployment examples throughout the documentation.

Changes ported from rke2-docs commit:
https://github.com/rancher/rke2-docs/commit/7821491