### PR TITLE
[sync rke2-docs] Update June 2026 release notes for v1.33-v1.36

### DIFF
--- a/versions/latest/modules/en/pages/release-notes/v1.33.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.33.X.adoc
@@ -1,6 +1,6 @@
 = v1.33.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1], v1.33.13+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13313[v1.33.13]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.33.12+rke2r2[v1.33.12+rke2r2], v1.33.12+rke2r2>>
 | May 28 2026
@@ -284,6 +301,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.29[Calico v3.29.3]
 | https://github.com/cilium/cilium/releases/tag/v1.17.3[v1.17.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.0[v4.2.0]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1]
+
+// v1.33.13+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.33.13.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.33.12+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10478[(#10478)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10514[(#10514)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10523[(#10523)]
+* 1.33 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10551[(#10551)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10562[(#10562)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10539[(#10539)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10547[(#10547)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10576[(#10576)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10579[(#10579)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10584[(#10584)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10607[(#10607)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10601[(#10601)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10596[(#10596)]
+* Update to v1.33.13 and Go v1.25.11 https://github.com/rancher/rke2/pull/10616[(#10616)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10627[(#10627)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10629[(#10629)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10657[(#10657)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.33.12+rke2r2[v1.33.12+rke2r2]
 

--- a/versions/latest/modules/en/pages/release-notes/v1.34.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.34.X.adoc
@@ -1,6 +1,6 @@
 = v1.34.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1], v1.34.9+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1349[v1.34.9]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.34.8+rke2r2[v1.34.8+rke2r2], v1.34.8+rke2r2>>
 | May 28 2026
@@ -199,6 +216,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.30[Calico v3.30.3]
 | https://github.com/cilium/cilium/releases/tag/v1.18.1[v1.18.1]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2[v4.2.2]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1]
+
+// v1.34.9+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.34.9.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.34.8+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10479[(#10479)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10515[(#10515)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10524[(#10524)]
+* 1.34 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10552[(#10552)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10563[(#10563)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10540[(#10540)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10548[(#10548)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10577[(#10577)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10580[(#10580)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10585[(#10585)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10608[(#10608)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10602[(#10602)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10597[(#10597)]
+* Update to v1.34.9 and Go v1.25.11 https://github.com/rancher/rke2/pull/10617[(#10617)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10628[(#10628)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10630[(#10630)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10658[(#10658)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.34.8+rke2r2[v1.34.8+rke2r2]
 

--- a/versions/latest/modules/en/pages/release-notes/v1.35.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.35.X.adoc
@@ -1,6 +1,6 @@
 = v1.35.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1], v1.35.6+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1356[v1.35.6]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.35.5+rke2r2[v1.35.5+rke2r2], v1.35.5+rke2r2>>
 | May 29 2026
@@ -165,6 +182,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.31[Calico v3.31.2]
 | https://github.com/cilium/cilium/releases/tag/v1.18.4[v1.18.4]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.3[v4.2.3]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1]
+
+// v1.35.6+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.35.6.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.35.5+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10480[(#10480)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10516[(#10516)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10525[(#10525)]
+* 1.35 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10553[(#10553)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10564[(#10564)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10541[(#10541)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10549[(#10549)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10578[(#10578)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10581[(#10581)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10586[(#10586)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10609[(#10609)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10603[(#10603)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10598[(#10598)]
+* Update to v1.35.6 and Go v1.25.11 https://github.com/rancher/rke2/pull/10618[(#10618)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10631[(#10631)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10632[(#10632)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10659[(#10659)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.35.5+rke2r2[v1.35.5+rke2r2]
 

--- a/versions/latest/modules/en/pages/release-notes/v1.36.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.36.X.adoc
@@ -1,6 +1,6 @@
 = v1.36.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1], v1.36.2+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1362[v1.36.2]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.36.1+rke2r2[v1.36.1+rke2r2], v1.36.1+rke2r2>>
 | May 28 2026
@@ -63,6 +80,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
 | https://github.com/cilium/cilium/releases/tag/v1.19.3[v1.19.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1]
+
+// v1.36.2+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.36.2.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.36.1+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10481[(#10481)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10517[(#10517)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10526[(#10526)]
+* 1.36 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10554[(#10554)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10565[(#10565)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10542[(#10542)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10550[(#10550)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10575[(#10575)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10582[(#10582)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10587[(#10587)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10610[(#10610)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10604[(#10604)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10599[(#10599)]
+* Update to v1.36.2 and Go v1.25.11 https://github.com/rancher/rke2/pull/10619[(#10619)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10633[(#10633)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10634[(#10634)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10660[(#10660)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.36.1+rke2r2[v1.36.1+rke2r2]
 

--- a/versions/latest/modules/zh/pages/release-notes/v1.33.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.33.X.adoc
@@ -1,6 +1,6 @@
 = v1.33.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1], v1.33.13+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13313[v1.33.13]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.33.12+rke2r2[v1.33.12+rke2r2], v1.33.12+rke2r2>>
 | May 28 2026
@@ -284,6 +301,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.29[Calico v3.29.3]
 | https://github.com/cilium/cilium/releases/tag/v1.17.3[v1.17.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.0[v4.2.0]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1]
+
+// v1.33.13+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.33.13.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.33.12+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10478[(#10478)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10514[(#10514)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10523[(#10523)]
+* 1.33 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10551[(#10551)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10562[(#10562)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10539[(#10539)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10547[(#10547)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10576[(#10576)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10579[(#10579)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10584[(#10584)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10607[(#10607)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10601[(#10601)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10596[(#10596)]
+* Update to v1.33.13 and Go v1.25.11 https://github.com/rancher/rke2/pull/10616[(#10616)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10627[(#10627)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10629[(#10629)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10657[(#10657)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.33.12+rke2r2[v1.33.12+rke2r2]
 

--- a/versions/latest/modules/zh/pages/release-notes/v1.34.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.34.X.adoc
@@ -1,6 +1,6 @@
 = v1.34.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1], v1.34.9+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1349[v1.34.9]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.34.8+rke2r2[v1.34.8+rke2r2], v1.34.8+rke2r2>>
 | May 28 2026
@@ -199,6 +216,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.30[Calico v3.30.3]
 | https://github.com/cilium/cilium/releases/tag/v1.18.1[v1.18.1]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2[v4.2.2]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1]
+
+// v1.34.9+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.34.9.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.34.8+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10479[(#10479)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10515[(#10515)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10524[(#10524)]
+* 1.34 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10552[(#10552)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10563[(#10563)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10540[(#10540)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10548[(#10548)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10577[(#10577)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10580[(#10580)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10585[(#10585)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10608[(#10608)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10602[(#10602)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10597[(#10597)]
+* Update to v1.34.9 and Go v1.25.11 https://github.com/rancher/rke2/pull/10617[(#10617)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10628[(#10628)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10630[(#10630)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10658[(#10658)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.34.8+rke2r2[v1.34.8+rke2r2]
 

--- a/versions/latest/modules/zh/pages/release-notes/v1.35.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.35.X.adoc
@@ -1,6 +1,6 @@
 = v1.35.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1], v1.35.6+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1356[v1.35.6]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.35.5+rke2r2[v1.35.5+rke2r2], v1.35.5+rke2r2>>
 | May 29 2026
@@ -165,6 +182,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.31[Calico v3.31.2]
 | https://github.com/cilium/cilium/releases/tag/v1.18.4[v1.18.4]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.3[v4.2.3]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1]
+
+// v1.35.6+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.35.6.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.35.5+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10480[(#10480)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10516[(#10516)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10525[(#10525)]
+* 1.35 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10553[(#10553)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10564[(#10564)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10541[(#10541)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10549[(#10549)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10578[(#10578)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10581[(#10581)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10586[(#10586)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10609[(#10609)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10603[(#10603)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10598[(#10598)]
+* Update to v1.35.6 and Go v1.25.11 https://github.com/rancher/rke2/pull/10618[(#10618)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10631[(#10631)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10632[(#10632)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10659[(#10659)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.35.5+rke2r2[v1.35.5+rke2r2]
 

--- a/versions/latest/modules/zh/pages/release-notes/v1.36.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.36.X.adoc
@@ -1,6 +1,6 @@
 = v1.36.X
 :page-languages: [en, zh]
-:revdate: 2026-06-12
+:revdate: 2026-07-03
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1], v1.36.2+rke2r1>>
+| Jun 25 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1362[v1.36.2]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1[v3.6.12-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1[v2.2.5-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.2[v1.4.2]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1[v0.8.1]
+| https://github.com/coredns/coredns/releases/tag/v1.14.4[v1.14.4]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.14.5-prime2[v1.14.5-prime2]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1[v0.17.1]
+| https://github.com/traefik/traefik/releases/tag/v3.7.4[v3.7.4]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.5[Flannel v0.28.5] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.0]
+| https://github.com/cilium/cilium/releases/tag/v1.19.4[v1.19.4]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.36.1+rke2r2[v1.36.1+rke2r2], v1.36.1+rke2r2>>
 | May 28 2026
@@ -63,6 +80,101 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
 | https://github.com/cilium/cilium/releases/tag/v1.19.3[v1.19.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1]
+
+// v1.36.2+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.36.2.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.36.1+rke2r2:
+
+* Set startup probes for etcd https://github.com/rancher/rke2/pull/10481[(#10481)]
+* Bump K3s/containerd/etcd/kine/spegel/klipper-helm https://github.com/rancher/rke2/pull/10517[(#10517)]
+* Set bootstrap to false for rke2-multus https://github.com/rancher/rke2/pull/10526[(#10526)]
+* 1.36 Bump ecm distro tools to v0.72.0 https://github.com/rancher/rke2/pull/10554[(#10554)]
+* Bump Traefik image and chart https://github.com/rancher/rke2/pull/10565[(#10565)]
+* Update CoreDNS chart 1.46.0 and Update Kubernetes Metrics Server chart 3.13.1 https://github.com/rancher/rke2/pull/10542[(#10542)]
+* CNI bumps for the 2026-06 Release Cycle https://github.com/rancher/rke2/pull/10550[(#10550)]
+* Bump snapshot-controller https://github.com/rancher/rke2/pull/10575[(#10575)]
+* Bump prime ingress nginx chart and image to v1.15.1 https://github.com/rancher/rke2/pull/10582[(#10582)]
+* Bump BCI images for CVE reasons https://github.com/rancher/rke2/pull/10587[(#10587)]
+* Bump k3s to remove golang version checks https://github.com/rancher/rke2/pull/10610[(#10610)]
+* Update Canal chart with crd fix https://github.com/rancher/rke2/pull/10604[(#10604)]
+* Update to coredns chart 1.46.002 https://github.com/rancher/rke2/pull/10599[(#10599)]
+* Update to v1.36.2 and Go v1.25.11 https://github.com/rancher/rke2/pull/10619[(#10619)]
+* Bump klipper-helm for CVE reasons https://github.com/rancher/rke2/pull/10633[(#10633)]
+* Fix missing arm64 checksum https://github.com/rancher/rke2/pull/10634[(#10634)]
+* Bump containerd to v2.2.5 https://github.com/rancher/rke2/pull/10660[(#10660)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.402.tgz[1.19.402]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.0-build2026060401.tgz[v3.32.0-build2026060401]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.003.tgz[v3.32.003]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.003.tgz[v3.32.003]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.002.tgz[1.46.002]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.101.tgz[4.15.101]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.100.tgz[3.13.100]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.5.0-rancher200.tgz[3.5.0-rancher200]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.12.100.tgz[1.12.100]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1100.tgz[0.2.1100]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.2800.tgz[0.1.2800]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.006.tgz[4.2.006]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.006.tgz[4.2.006]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.003.tgz[40.1.003]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.003.tgz[40.1.003]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.36.1+rke2r2[v1.36.1+rke2r2]
 


### PR DESCRIPTION
This commit adds the June 2026 releases across all active version lines:
- v1.33.13+rke2r1 (Jun 25 2026)
- v1.34.9+rke2r1 (Jun 25 2026)
- v1.35.6+rke2r1 (Jun 25 2026)
- v1.36.2+rke2r1 (Jun 25 2026)

Changes:
- Added new release entries to version tables with component versions
- Added full release sections with changelog and charts versions
- Included Traefik v40.x upgrade warning about kubernetesIngressNGINX provider name change
- Used v1.14.5-prime2 for ingress-nginx versions
- Updated revdate to 2026-07-03
- Applied changes to both English and Chinese versions

Changes ported from rke2-docs commit:
https://github.com/rancher/rke2-docs/commit/dd26169367d3c11e550dc05beba7e926d6a6877f