### PR TITLE
[sync rke2-docs] Add documentation for nftables support

### DIFF
--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -351,7 +351,7 @@ Some cloud providers, such as Linode, will create machines with "localhost" as t
 [WARNING]
 .Experimental
 ====
-nftables support in rke2 is considered experimental.
+Support for `nftables` in RKE2 is considered experimental.
 ====
 
 [NOTE]

--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -368,7 +368,7 @@ Linux 3.13 introduced `nftables` as a modern replacement for `iptables`. Key fea
 
 Using nftables is now supported by kube-proxy and most CNIs currently bundled with rke2.
 
-To use nftables with kube-proxy, set the following parameter in `config.yaml`:
+To use `nftables` with `kube-proxy`, set the following parameter in `config.yaml`:
 
 [,yaml]
 ----

--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -357,7 +357,7 @@ Support for `nftables` in RKE2 is considered experimental.
 [NOTE]
 .Version Gate
 ====
-nftables support is available as of the July 2026 releases v1.36.3+rke2r1, v1.35.7+rke2r1, v1.34.10+rke2r1.
+Support for `nftables` is available as of the July 2026 releases v1.36.3+rke2r1, v1.35.7+rke2r1, and v1.34.10+rke2r1.
 ====
 
 **nftables** is a modern replacement for iptables, introduced in Linux 3.13. It consolidates all rule management into a single interface, supports atomic batch updates (all rule changes commit together or not at all), and offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.

--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -1,6 +1,6 @@
 = Network Options
 :page-languages: [en, zh]
-:revdate: 2026-05-29
+:revdate: 2026-07-10
 :page-revdate: {revdate}
 
 Kubernetes requires installation of one or more CNI Plugins to provide Pod networking. RKE2 bundles four primary CNI Plugins: Canal, Cilium, Calico, and Flannel. Only Calico and Flannel support Microsoft Windows. RKE2 also includes Multus as a secondary CNI Plugin, which must be enabled alongside a primary CNI Plugin. For more information, see the xref:networking/multus_sriov.adoc[Multus] documentation.
@@ -345,3 +345,106 @@ spec:
 == Nodes Without a Hostname
 
 Some cloud providers, such as Linode, will create machines with "localhost" as the hostname and others may not have a hostname set at all. This can cause problems with domain name resolution. You can run RKE2 with the `node-name` parameter and this will pass the node name to resolve this issue.
+
+== Nftables support
+
+[WARNING]
+.Experimental
+====
+nftables support in rke2 is considered experimental.
+====
+
+[NOTE]
+.Version Gate
+====
+nftables support is available as of the July 2026 releases v1.36.3+rke2r1, v1.35.7+rke2r1, v1.34.10+rke2r1.
+====
+
+**nftables** is a modern replacement for iptables, introduced in Linux 3.13. It consolidates all rule management into a single interface, supports atomic batch updates (all rule changes commit together or not at all), and offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.
+
+Using nftables is now supported by kube-proxy and most CNIs currently bundled with rke2.
+
+To use nftables with kube-proxy, set the following parameter in `config.yaml`:
+
+[,yaml]
+----
+kube-proxy-arg:
+  - proxy-mode=nftables
+----
+
+Each CNI needs to be configured through its HelmChartConfig.
+
+[tabs]
+====
+Canal CNI Plugin::
++
+--
+For Canal, set the following HelmChartConfig:
+
+[,yaml]
+----
+# /var/lib/rancher/rke2/server/manifests/rke2-canal-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-canal
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    flannel:
+      enableNFTables: true
+    calico:
+      felixIptablesBackend: nft
+----
+--
+
+Cilium CNI Plugin::
++
+--
+Cilium uses eBPF as its filtering mechanism instead of iptables/nftables so there is nothing to configure.
+--
+
+Calico CNI Plugin::
++
+--
+For Calico, set the following HelmChartConfig:
+
+[,yaml]
+----
+# /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-calico
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    installation:
+      calicoNetwork:
+        linuxDataplane: Nftables
+----
+--
+
+Flannel CNI Plugin::
++
+--
+For Flannel, set the following HelmChartConfig:
+
+[,yaml]
+----
+# /var/lib/rancher/rke2/server/manifests/rke2-flannel-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-flannel
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    flannel:
+      enableNFTables: true
+----
+--
+====

--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -346,7 +346,7 @@ spec:
 
 Some cloud providers, such as Linode, will create machines with "localhost" as the hostname and others may not have a hostname set at all. This can cause problems with domain name resolution. You can run RKE2 with the `node-name` parameter and this will pass the node name to resolve this issue.
 
-== Nftables support
+== nftables support
 
 [WARNING]
 .Experimental

--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -366,7 +366,7 @@ Linux 3.13 introduced `nftables` as a modern replacement for `iptables`. Key fea
 * Supports atomic batch updates (all rule changes commit together or not at all).
 * Offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.
 
-Using nftables is now supported by kube-proxy and most CNIs currently bundled with rke2.
+Using nftables is now supported by kube-proxy and all CNI plugins currently bundled with rke2.
 
 To use `nftables` with `kube-proxy`, set the following parameter in `config.yaml`:
 
@@ -376,14 +376,14 @@ kube-proxy-arg:
   - proxy-mode=nftables
 ----
 
-Each CNI needs to be configured through its HelmChartConfig.
+Each CNI needs to be configured through its `HelmChartConfig`.
 
 [tabs]
 ====
 Canal CNI Plugin::
 +
 --
-For Canal, set the following HelmChartConfig:
+For Canal, set the following `HelmChartConfig`:
 
 [,yaml]
 ----
@@ -406,13 +406,13 @@ spec:
 Cilium CNI Plugin::
 +
 --
-Cilium uses eBPF as its filtering mechanism instead of iptables/nftables so there is nothing to configure.
+There is nothing to configure. Cilium uses eBPF as its filtering mechanism instead of `iptables` or `nftables`.
 --
 
 Calico CNI Plugin::
 +
 --
-For Calico, set the following HelmChartConfig:
+For Calico, set the following `HelmChartConfig`:
 
 [,yaml]
 ----
@@ -434,7 +434,7 @@ spec:
 Flannel CNI Plugin::
 +
 --
-For Flannel, set the following HelmChartConfig:
+For Flannel, set the following `HelmChartConfig`:
 
 [,yaml]
 ----

--- a/versions/latest/modules/en/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/en/pages/networking/basic_network_options.adoc
@@ -360,7 +360,11 @@ Support for `nftables` in RKE2 is considered experimental.
 Support for `nftables` is available as of the July 2026 releases v1.36.3+rke2r1, v1.35.7+rke2r1, and v1.34.10+rke2r1.
 ====
 
-**nftables** is a modern replacement for iptables, introduced in Linux 3.13. It consolidates all rule management into a single interface, supports atomic batch updates (all rule changes commit together or not at all), and offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.
+Linux 3.13 introduced `nftables` as a modern replacement for `iptables`. Key features of `nftables` include:
+
+* Consolidates all rule management into a single interface.
+* Supports atomic batch updates (all rule changes commit together or not at all).
+* Offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.
 
 Using nftables is now supported by kube-proxy and most CNIs currently bundled with rke2.
 

--- a/versions/latest/modules/zh/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/zh/pages/networking/basic_network_options.adoc
@@ -1,6 +1,6 @@
 = Network Options
 :page-languages: [en, zh]
-:revdate: 2026-05-29
+:revdate: 2026-07-10
 :page-revdate: {revdate}
 
 Kubernetes requires installation of one or more CNI Plugins to provide Pod networking. RKE2 bundles four primary CNI Plugins: Canal, Cilium, Calico, and Flannel. Only Calico and Flannel support Microsoft Windows. RKE2 also includes Multus as a secondary CNI Plugin, which must be enabled alongside a primary CNI Plugin. For more information, see the xref:networking/multus_sriov.adoc[Multus] documentation.
@@ -344,3 +344,106 @@ spec:
 == Nodes Without a Hostname
 
 Some cloud providers, such as Linode, will create machines with "localhost" as the hostname and others may not have a hostname set at all. This can cause problems with domain name resolution. You can run RKE2 with the `node-name` parameter and this will pass the node name to resolve this issue.
+
+== Nftables support
+
+[WARNING]
+.Experimental
+====
+nftables support in rke2 is considered experimental.
+====
+
+[NOTE]
+.Version Gate
+====
+nftables support is available as of the July 2026 releases v1.36.3+rke2r1, v1.35.7+rke2r1, v1.34.10+rke2r1.
+====
+
+**nftables** is a modern replacement for iptables, introduced in Linux 3.13. It consolidates all rule management into a single interface, supports atomic batch updates (all rule changes commit together or not at all), and offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.
+
+Using nftables is now supported by kube-proxy and most CNIs currently bundled with rke2.
+
+To use nftables with kube-proxy, set the following parameter in `config.yaml`:
+
+[,yaml]
+----
+kube-proxy-arg:
+  - proxy-mode=nftables
+----
+
+Each CNI needs to be configured through its HelmChartConfig.
+
+[tabs]
+====
+Canal CNI Plugin::
++
+--
+For Canal, set the following HelmChartConfig:
+
+[,yaml]
+----
+# /var/lib/rancher/rke2/server/manifests/rke2-canal-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-canal
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    flannel:
+      enableNFTables: true
+    calico:
+      felixIptablesBackend: nft
+----
+--
+
+Cilium CNI Plugin::
++
+--
+Cilium uses eBPF as its filtering mechanism instead of iptables/nftables so there is nothing to configure.
+--
+
+Calico CNI Plugin::
++
+--
+For Calico, set the following HelmChartConfig:
+
+[,yaml]
+----
+# /var/lib/rancher/rke2/server/manifests/rke2-calico-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-calico
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    installation:
+      calicoNetwork:
+        linuxDataplane: Nftables
+----
+--
+
+Flannel CNI Plugin::
++
+--
+For Flannel, set the following HelmChartConfig:
+
+[,yaml]
+----
+# /var/lib/rancher/rke2/server/manifests/rke2-flannel-config.yaml
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-flannel
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    flannel:
+      enableNFTables: true
+----
+--
+====

--- a/versions/latest/modules/zh/pages/networking/basic_network_options.adoc
+++ b/versions/latest/modules/zh/pages/networking/basic_network_options.adoc
@@ -345,25 +345,29 @@ spec:
 
 Some cloud providers, such as Linode, will create machines with "localhost" as the hostname and others may not have a hostname set at all. This can cause problems with domain name resolution. You can run RKE2 with the `node-name` parameter and this will pass the node name to resolve this issue.
 
-== Nftables support
+== nftables support
 
 [WARNING]
 .Experimental
 ====
-nftables support in rke2 is considered experimental.
+Support for `nftables` in RKE2 is considered experimental.
 ====
 
 [NOTE]
 .Version Gate
 ====
-nftables support is available as of the July 2026 releases v1.36.3+rke2r1, v1.35.7+rke2r1, v1.34.10+rke2r1.
+Support for `nftables` is available as of the July 2026 releases v1.36.3+rke2r1, v1.35.7+rke2r1, and v1.34.10+rke2r1.
 ====
 
-**nftables** is a modern replacement for iptables, introduced in Linux 3.13. It consolidates all rule management into a single interface, supports atomic batch updates (all rule changes commit together or not at all), and offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.
+Linux 3.13 introduced `nftables` as a modern replacement for `iptables`. Key features of `nftables` include:
 
-Using nftables is now supported by kube-proxy and most CNIs currently bundled with rke2.
+* Consolidates all rule management into a single interface.
+* Supports atomic batch updates (all rule changes commit together or not at all).
+* Offers improved performance for complex rule sets due to better kernel integration and support for set-based matching.
 
-To use nftables with kube-proxy, set the following parameter in `config.yaml`:
+Using nftables is now supported by kube-proxy and all CNI plugins currently bundled with rke2.
+
+To use `nftables` with `kube-proxy`, set the following parameter in `config.yaml`:
 
 [,yaml]
 ----
@@ -371,14 +375,14 @@ kube-proxy-arg:
   - proxy-mode=nftables
 ----
 
-Each CNI needs to be configured through its HelmChartConfig.
+Each CNI needs to be configured through its `HelmChartConfig`.
 
 [tabs]
 ====
 Canal CNI Plugin::
 +
 --
-For Canal, set the following HelmChartConfig:
+For Canal, set the following `HelmChartConfig`:
 
 [,yaml]
 ----
@@ -401,13 +405,13 @@ spec:
 Cilium CNI Plugin::
 +
 --
-Cilium uses eBPF as its filtering mechanism instead of iptables/nftables so there is nothing to configure.
+There is nothing to configure. Cilium uses eBPF as its filtering mechanism instead of `iptables` or `nftables`.
 --
 
 Calico CNI Plugin::
 +
 --
-For Calico, set the following HelmChartConfig:
+For Calico, set the following `HelmChartConfig`:
 
 [,yaml]
 ----
@@ -429,7 +433,7 @@ spec:
 Flannel CNI Plugin::
 +
 --
-For Flannel, set the following HelmChartConfig:
+For Flannel, set the following `HelmChartConfig`:
 
 [,yaml]
 ----


### PR DESCRIPTION
This commit ports the nftables support documentation from rke2-docs to rke2-product-docs.

Changes:
- Added new "Nftables support" section documenting experimental nftables support
- Updated revdate to 2026-07-10 for both en and zh versions
- Documented nftables configuration for kube-proxy and all CNI plugins (Canal, Cilium, Calico, Flannel)
- Converted from Markdown/Docusaurus format to AsciiDoc/Antora format
- Applied changes to both English (en) and Chinese (zh) language versions

Source: https://github.com/rancher/rke2-docs/pull/583
Commit: 1bb832b16028ec69c3963961361448bb55ecb280