### PR TITLE
[sync rke2-docs] Remove all EOL Version Gates

### DIFF
--- a/versions/latest/modules/en/pages/advanced.adoc
+++ b/versions/latest/modules/en/pages/advanced.adoc
@@ -1,6 +1,6 @@
 = Advanced Options and Configuration
 :page-languages: [en, zh]
-:revdate: 2026-03-10
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 This section contains advanced information describing the different ways you can run and manage RKE2.
@@ -289,12 +289,6 @@ The following options are available under the `server` sub-command for RKE2. The
 In order to mount a volume as read only, append `:ro` to the end of the volume mount: `/source/volume/path/on/host:/destination/volume/path/in/staticpod:ro`
 
 Multiple volume mounts can be specified for the same component by passing the flag values as an array in the config file.
-
-[IMPORTANT]
-.Version Gate
-====
-Prior to April 2024 releases (v1.27.13+rke2r1, v1.28.9+rke2r1, v1.29.4+rke2r1), only directories can be mounted.
-====
 
 [,yaml]
 ----

--- a/versions/latest/modules/en/pages/datastore/backup_restore.adoc
+++ b/versions/latest/modules/en/pages/datastore/backup_restore.adoc
@@ -1,7 +1,7 @@
 
 = Backup and Restore
 :page-languages: [en, zh]
-:revdate: 2026-02-27
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 :page-aliases: backup_restore.adoc
 
@@ -216,12 +216,6 @@ Starting in versions v1.34.0+rke2r1, v1.33.4+rke2r1, v1.32.8+rke2r1, v1.31.12+rk
 |===
 
 === S3 Configuration Secret Support
-
-[IMPORTANT]
-.Version Gate
-====
-S3 Configuration Secret support is available as of the August 2024 releases: v1.30.4+rke2r1, v1.29.8+rke2r1, v1.28.13+rke2r1
-====
 
 RKE2 supports reading etcd S3 snapshot configuration from a Kubernetes Secret.
 This may be preferred to hardcoding credentials in RKE2 CLI flags or config files for security reasons, or if credentials need to be rotated without restarting RKE2.

--- a/versions/latest/modules/en/pages/install/configuration.adoc
+++ b/versions/latest/modules/en/pages/install/configuration.adoc
@@ -1,6 +1,6 @@
 = Configuration Options
 :page-languages: [en, zh]
-:revdate: 2026-01-16
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 == Configuration File
@@ -91,12 +91,6 @@ node-taint:
 ----
 
 == Kubelet Configuration
-
-[NOTE]
-.Version Gate
-====
-The drop-in directory for kubelet configuration files or the config file (options 1 and 2 below) are only available in v1.32 and above. For lower minors, you should use the kubelet args directly (option number 3 below).
-====
 
 Following on from upstream behavior, kubelet configuration can be changed in different ways with a specific https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/#kubelet-configuration-merging-order[order of precedence].
 

--- a/versions/latest/modules/en/pages/install/private_registry.adoc
+++ b/versions/latest/modules/en/pages/install/private_registry.adoc
@@ -1,6 +1,6 @@
 = Private Registry Configuration
 :page-languages: [en, zh]
-:revdate: 2026-05-11
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
@@ -21,12 +21,6 @@ Containerd has an implicit "default endpoint" for all registries. The default en
 * The default endpoint for all other registries is `\https://<REGISTRY>/v2`, where `<REGISTRY>` is the registry hostname and optional port.
 
 In order to be recognized as a registry, the first component of the image name must contain at least one period or colon. For historical reasons, images without a registry specified in their name are implicitly identified as being from `docker.io`.
-
-[NOTE]
-.Version Gate
-====
-The `disable-default-registry-endpoint` option is available as of February 2024 releases: v1.26.13+rke2r1, v1.27.10+rke2r1, v1.28.6+rke2r1, v1.29.1+rke2r1
-====
 
 Nodes may be configured with the `disable-default-registry-endpoint: true` option. When this is set, containerd will not fall back to the default registry endpoint, and will only pull from configured mirror endpoints, along with the distributed registry if it is enabled.
 
@@ -108,12 +102,6 @@ mirrors:
       "^rancher/(.*)": "mirrorproject/rancher-images/$1"
 ----
 
-[NOTE]
-.Version Gate
-====
-Rewrites are no longer applied to the Default Endpoint as of the February 2024 releases: v1.26.13+rke2r1, v1.27.10+rke2r1, v1.28.6+rke2r1, v1.29.1+rke2r1. Prior to these releases, rewrites were also applied to the default endpoint, which would prevent RKE2 from pulling from the upstream registry if the image could not be pulled from a mirror endpoint, and the image was not available under the modified name in the upstream.
-====
-
 If you want to apply rewrites when pulling directly from a registry - when it is not being used as a mirror for a different upstream registry - you must provide a mirror endpoint that does not match the default endpoint. Mirror endpoints in `registries.yaml` that match the default endpoint are ignored; the default endpoint is always tried last with no rewrites, if fallback has not been disabled.
 
 For example, if you have a registry at `\https://registry.example.com/`, and want to apply rewrites when explicitly pulling `registry.example.com/rancher/rke2-runtime:v1.30.1-rke2r1`, you can add a mirror endpoint with the port listed. Because the mirror endpoint does not match the default endpoint - *`"\https://registry.example.com:443/v2" != "\https://registry.example.com/v2"`* - the endpoint is accepted as a mirror and rewrites are applied, despite it being effectively the same as the default.
@@ -170,12 +158,6 @@ The `auth` part consists of either username/password or authentication token:
 Below are basic examples of using private registries in different modes:
 
 === Wildcard Support
-
-[NOTE]
-.Version Gate
-====
-Wildcard support is available as of the March 2024 releases: v1.26.15+rke2r1, v1.27.12+rke2r1, v1.28.8+rke2r1, v1.29.3+rke2r1
-====
 
 The `"*"` wildcard entry can be used in the `mirrors` and `configs` sections to provide default configuration for all registries. The default configuration will only be used if there is no specific entry for that registry. Note that the asterisk MUST be quoted.
 

--- a/versions/latest/modules/en/pages/install/registry_mirror.adoc
+++ b/versions/latest/modules/en/pages/install/registry_mirror.adoc
@@ -1,13 +1,7 @@
 = Embedded Registry Mirror
 :page-languages: [en, zh]
-:revdate: 2026-05-11
+:revdate: 2026-07-24
 :page-revdate: {revdate}
-
-[NOTE]
-.Version Gate
-====
-The Embedded Registry Mirror is available as an experimental feature as of January 2024 releases: v1.26.13+rke2r1, v1.27.10+rke2r1, v1.28.6+rke2r1, v1.29.1+rke2r1 and GA as of December 2024 releases: v1.29.12+rke2r1,v1.30.8+rke2r1, v1.31.4+rke2r1.
-====
 
 RKE2 embeds https://github.com/spegel-org/spegel[Spegel], a stateless distributed OCI registry mirror that allows peer-to-peer sharing of container images between nodes in a Kubernetes cluster. The distributed registry mirror is disabled by default. For RKE2 to leverage it, you must enable both the <<Enabling The Distributed OCI Registry Mirror,Distributed OCI Registry Mirror>> and the <<Enabling Registry Mirroring,Registry mirroring>> as explained in the following subsections.
 
@@ -61,12 +55,6 @@ If you are using a private registry directly, instead of as a mirror for an upst
 mirrors:
   mirror.example.com:
 ----
-
-[NOTE]
-.Version Gate
-====
-Wildcard support is available as of the March 2024 releases: v1.26.15+rke2r1, v1.27.12+rke2r1, v1.28.8+rke2r1, v1.29.3+rke2r1
-====
 
 The `"*"` wildcard mirror entry can be used to enable distributed mirroring of all registries. Note that the asterisk MUST be quoted:
 

--- a/versions/latest/modules/en/pages/networking/networking_services.adoc
+++ b/versions/latest/modules/en/pages/networking/networking_services.adoc
@@ -1,6 +1,6 @@
 = Networking Services
 :page-languages: [en, zh]
-:revdate: 2026-06-26
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 This page explains how CoreDNS and the Nginx-Ingress controller work within RKE2.
@@ -155,12 +155,6 @@ For more information, refer to the official https://github.com/rancher/rke2-char
 Traefik::
 +
 --
-[IMPORTANT]
-.Version Gate
-====
-Traefik support is available as of August 2024 releases: v1.28.12+rke2r1, v1.29.7+rke2r1, v1.30.3+rke2r1.
-====
-
 https://doc.traefik.io/traefik/[Traefik] is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease. It simplifies networking complexity while designing, deploying, and running applications.
 
 To use Traefik, start each server with the `ingress-controller: traefik` option in your configuration file.

--- a/versions/latest/modules/en/pages/security/pod_security_standards.adoc
+++ b/versions/latest/modules/en/pages/security/pod_security_standards.adoc
@@ -1,15 +1,9 @@
 = Default Pod Security Standards
 :page-languages: [en, zh]
-:revdate: 2025-07-17
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 This document describes how RKE2 configures `PodSecurityStandards` and `NetworkPolicies` in order to be secure-by-default while also providing operators with maximum configuration flexibility.
-
-[IMPORTANT]
-.Version Gate
-====
-This document applies to RKE2 v1.25 and newer, please refer to the xref:security/pod_security_policies.adoc[Pod Security Policies Documentation] for the default policy information for RKE2 v1.24 and older.
-====
 
 == Pod Security Standards
 

--- a/versions/latest/modules/en/pages/security/secrets_encryption.adoc
+++ b/versions/latest/modules/en/pages/security/secrets_encryption.adoc
@@ -1,6 +1,6 @@
 = Secrets Encryption
 :page-languages: [en, zh]
-:revdate: 2026-05-25
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 == Secrets Encryption Config
@@ -95,14 +95,6 @@ Failure to follow proper procedure when rotating secrets encryption keys can cau
 ====
 
 === Encryption Key Rotation
-
-[NOTE]
-.Version Gate
-====
-Available as of the September 2024 releases: v1.29.9+rke2r1, v1.30.5+rke2r1, v1.31.1+rke2r1.
-====
-
-For older releases, see <<Encryption Key Rotation Classic>>.
 
 [tabs]
 ======

--- a/versions/latest/modules/zh/pages/datastore/backup_restore.adoc
+++ b/versions/latest/modules/zh/pages/datastore/backup_restore.adoc
@@ -1,6 +1,6 @@
 = Backup and Restore
 :page-languages: [en, zh]
-:revdate: 2026-02-27
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 :page-aliases: backup_restore.adoc
 
@@ -215,12 +215,6 @@ Starting in versions v1.34.0+rke2r1, v1.33.4+rke2r1, v1.32.8+rke2r1, v1.31.12+rk
 |===
 
 === S3 Configuration Secret Support
-
-[IMPORTANT]
-.Version Gate
-====
-S3 Configuration Secret support is available as of the August 2024 releases: v1.30.4+rke2r1, v1.29.8+rke2r1, v1.28.13+rke2r1
-====
 
 RKE2 supports reading etcd S3 snapshot configuration from a Kubernetes Secret.
 This may be preferred to hardcoding credentials in RKE2 CLI flags or config files for security reasons, or if credentials need to be rotated without restarting RKE2.

--- a/versions/latest/modules/zh/pages/install/private_registry.adoc
+++ b/versions/latest/modules/zh/pages/install/private_registry.adoc
@@ -1,6 +1,6 @@
 = Private Registry Configuration
 :page-languages: [en, zh]
-:revdate: 2026-05-11
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.
@@ -21,12 +21,6 @@ Containerd has an implicit "default endpoint" for all registries. The default en
 * The default endpoint for all other registries is `\https://<REGISTRY>/v2`, where `<REGISTRY>` is the registry hostname and optional port.
 
 In order to be recognized as a registry, the first component of the image name must contain at least one period or colon. For historical reasons, images without a registry specified in their name are implicitly identified as being from `docker.io`.
-
-[NOTE]
-.Version Gate
-====
-The `disable-default-registry-endpoint` option is available as of February 2024 releases: v1.26.13+rke2r1, v1.27.10+rke2r1, v1.28.6+rke2r1, v1.29.1+rke2r1
-====
 
 Nodes may be configured with the `disable-default-registry-endpoint: true` option. When this is set, containerd will not fall back to the default registry endpoint, and will only pull from configured mirror endpoints, along with the distributed registry if it is enabled.
 
@@ -108,12 +102,6 @@ mirrors:
       "^rancher/(.*)": "mirrorproject/rancher-images/$1"
 ----
 
-[NOTE]
-.Version Gate
-====
-Rewrites are no longer applied to the Default Endpoint as of the February 2024 releases: v1.26.13+rke2r1, v1.27.10+rke2r1, v1.28.6+rke2r1, v1.29.1+rke2r1. Prior to these releases, rewrites were also applied to the default endpoint, which would prevent RKE2 from pulling from the upstream registry if the image could not be pulled from a mirror endpoint, and the image was not available under the modified name in the upstream.
-====
-
 If you want to apply rewrites when pulling directly from a registry - when it is not being used as a mirror for a different upstream registry - you must provide a mirror endpoint that does not match the default endpoint. Mirror endpoints in `registries.yaml` that match the default endpoint are ignored; the default endpoint is always tried last with no rewrites, if fallback has not been disabled.
 
 For example, if you have a registry at `\https://registry.example.com/`, and want to apply rewrites when explicitly pulling `registry.example.com/rancher/rke2-runtime:v1.30.1-rke2r1`, you can add a mirror endpoint with the port listed. Because the mirror endpoint does not match the default endpoint - *`"\https://registry.example.com:443/v2" != "\https://registry.example.com/v2"`* - the endpoint is accepted as a mirror and rewrites are applied, despite it being effectively the same as the default.
@@ -170,12 +158,6 @@ The `auth` part consists of either username/password or authentication token:
 Below are basic examples of using private registries in different modes:
 
 === Wildcard Support
-
-[NOTE]
-.Version Gate
-====
-Wildcard support is available as of the March 2024 releases: v1.26.15+rke2r1, v1.27.12+rke2r1, v1.28.8+rke2r1, v1.29.3+rke2r1
-====
 
 The `"*"` wildcard entry can be used in the `mirrors` and `configs` sections to provide default configuration for all registries. The default configuration will only be used if there is no specific entry for that registry. Note that the asterisk MUST be quoted.
 

--- a/versions/latest/modules/zh/pages/install/registry_mirror.adoc
+++ b/versions/latest/modules/zh/pages/install/registry_mirror.adoc
@@ -1,13 +1,7 @@
 = Embedded Registry Mirror
 :page-languages: [en, zh]
-:revdate: 2026-05-11
+:revdate: 2026-07-24
 :page-revdate: {revdate}
-
-[NOTE]
-.Version Gate
-====
-The Embedded Registry Mirror is available as an experimental feature as of January 2024 releases: v1.26.13+rke2r1, v1.27.10+rke2r1, v1.28.6+rke2r1, v1.29.1+rke2r1 and GA as of December 2024 releases: v1.29.12+rke2r1,v1.30.8+rke2r1, v1.31.4+rke2r1.
-====
 
 RKE2 embeds https://github.com/spegel-org/spegel[Spegel], a stateless distributed OCI registry mirror that allows peer-to-peer sharing of container images between nodes in a Kubernetes cluster. The distributed registry mirror is disabled by default. For RKE2 to leverage it, you must enable both the <<Enabling The Distributed OCI Registry Mirror,Distributed OCI Registry Mirror>> and the <<Enabling Registry Mirroring,Registry mirroring>> as explained in the following subsections.
 
@@ -61,12 +55,6 @@ If you are using a private registry directly, instead of as a mirror for an upst
 mirrors:
   mirror.example.com:
 ----
-
-[NOTE]
-.Version Gate
-====
-Wildcard support is available as of the March 2024 releases: v1.26.15+rke2r1, v1.27.12+rke2r1, v1.28.8+rke2r1, v1.29.3+rke2r1
-====
 
 The `"*"` wildcard mirror entry can be used to enable distributed mirroring of all registries. Note that the asterisk MUST be quoted:
 

--- a/versions/latest/modules/zh/pages/networking/networking_services.adoc
+++ b/versions/latest/modules/zh/pages/networking/networking_services.adoc
@@ -1,6 +1,6 @@
 = Networking Services
 :page-languages: [en, zh]
-:revdate: 2026-06-26
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 This page explains how CoreDNS and the Nginx-Ingress controller work within RKE2.
@@ -155,12 +155,6 @@ For more information, refer to the official https://github.com/kubernetes/ingres
 Traefik::
 +
 --
-[IMPORTANT]
-.Version Gate
-====
-Traefik support is available as of August 2024 releases: v1.28.12+rke2r1, v1.29.7+rke2r1, v1.30.3+rke2r1.
-====
-
 https://doc.traefik.io/traefik/[Traefik] is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease. It simplifies networking complexity while designing, deploying, and running applications.
 
 To use Traefik, start each server with the `ingress-controller: traefik` option in your configuration file.

--- a/versions/latest/modules/zh/pages/security/secrets_encryption.adoc
+++ b/versions/latest/modules/zh/pages/security/secrets_encryption.adoc
@@ -1,6 +1,6 @@
 = Secrets Encryption
 :page-languages: [en, zh]
-:revdate: 2026-05-25
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 == Secrets Encryption Config
@@ -95,14 +95,6 @@ Failure to follow proper procedure when rotating secrets encryption keys can cau
 ====
 
 === Encryption Key Rotation
-
-[NOTE]
-.Version Gate
-====
-Available as of the September 2024 releases: v1.29.9+rke2r1, v1.30.5+rke2r1, v1.31.1+rke2r1.
-====
-
-For older releases, see <<Encryption Key Rotation Classic>>.
 
 [tabs]
 ======


### PR DESCRIPTION
Remove Version Gate admonitions that reference EOL RKE2 releases, since the gated features are now available in all supported versions. Affected pages: advanced, datastore/backup_restore, install/configuration, install/private_registry, install/registry_mirror, networking/networking_services, security/pod_security_standards and security/secrets_encryption.

Kept the still-relevant gates (containerd 2.0, Choosing Encryption Provider, S3 Retention). Applied to en and mirrored to zh where the gates existed (advanced, configuration and pod_security_standards had no gate in zh); revdates bumped on changed pages.

Ported from rke2-docs PR: https://github.com/rancher/rke2-docs/pull/593