### PR TITLE
[sync rke2-docs] Modify GPU docs

### DIFF
--- a/versions/latest/modules/en/pages/add-ons/gpu_operators.adoc
+++ b/versions/latest/modules/en/pages/add-ons/gpu_operators.adoc
@@ -1,6 +1,6 @@
 = GPU Operators
 :page-languages: [en, zh]
-:revdate: 2026-06-25
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 == Deploy NVIDIA operator
@@ -158,8 +158,10 @@ spec:
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-
-    cdi:
-      nriPluginEnabled: true
+    toolkit:
+      env:
+      - name: CONTAINERD_SOCKET
+        value: /run/k3s/containerd/containerd.sock
 ----
 
 If your operating system vendor supplies a compatible driver image, you can use the `driver` value field to point to it. For example, in SLES 16.0, you can use the following manifest:
@@ -178,23 +180,53 @@ spec:
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-
-    cdi:
-      nriPluginEnabled: true
+    toolkit:
+      env:
+      - name: CONTAINERD_SOCKET
+        value: /run/k3s/containerd/containerd.sock
     driver:
       repository: registry.suse.com/third-party/nvidia
       usePrecompiled: true
       version: 595 # This depends on the nvidia driver that works with your GPU architecture
 ----
 
-[NOTE]
+--
+
+v26.3.x with NRI::
++
+--
+
+https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/cdi.html#about-the-node-resource-interface-nri-plugin[Node Resource Interface (NRI) specification] is a pluggable extension mechanism built into container runtimes like containerd and CRI-O that allows custom plugins to intercept container lifecycle events on a node. It is considered the future integration mechanism for GPUs.
+
+[WARNING]
 ====
-NVIDIA GPU Operator v26.3.x recommends using https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/cdi.html#about-the-node-resource-interface-nri-plugin[Node Resource Interface (NRI) specification] and that simplifies operations: we don't need to pass any extra envvar and it does not require changing containerd configuration. It requires containerd 2.1.
+NVIDIA considers NRI as experimental
 ====
+
+If you want to try it out, please use the following manifest:
+
+[,yaml]
+----
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: gpu-operator
+  namespace: kube-system
+spec:
+  repo: https://helm.ngc.nvidia.com/nvidia
+  chart: gpu-operator
+  version: v26.3.1
+  targetNamespace: gpu-operator
+  createNamespace: true
+  valuesContent: |-
+    cdi:
+      nriPluginEnabled: true
+----
 
 [IMPORTANT]
 .Version Gate
 ====
-Containerd 2.1 is available as of September 2025 releases: v1.31.13+rke2r1, v1.32.9+rke2r1, v1.33.5+rke2r1, v1.34.1+rke2r1
+NRI requires containerd 2.1. Containerd 2.1 is available as of September 2025 releases: v1.31.13+rke2r1, v1.32.9+rke2r1, v1.33.5+rke2r1, v1.34.1+rke2r1
 ====
 
 --

--- a/versions/latest/modules/zh/pages/add-ons/gpu_operators.adoc
+++ b/versions/latest/modules/zh/pages/add-ons/gpu_operators.adoc
@@ -1,6 +1,6 @@
 = GPU Operators
 :page-languages: [en, zh]
-:revdate: 2026-05-29
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 == Deploy NVIDIA operator
@@ -158,8 +158,10 @@ spec:
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-
-    cdi:
-      nriPluginEnabled: true
+    toolkit:
+      env:
+      - name: CONTAINERD_SOCKET
+        value: /run/k3s/containerd/containerd.sock
 ----
 
 If your operating system vendor supplies a compatible driver image, you can use the `driver` value field to point to it. For example, in SLES 16.0, you can use the following manifest:
@@ -178,23 +180,53 @@ spec:
   targetNamespace: gpu-operator
   createNamespace: true
   valuesContent: |-
-    cdi:
-      nriPluginEnabled: true
+    toolkit:
+      env:
+      - name: CONTAINERD_SOCKET
+        value: /run/k3s/containerd/containerd.sock
     driver:
       repository: registry.suse.com/third-party/nvidia
       usePrecompiled: true
       version: 595 # This depends on the nvidia driver that works with your GPU architecture
 ----
 
-[NOTE]
+--
+
+v26.3.x with NRI::
++
+--
+
+https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/cdi.html#about-the-node-resource-interface-nri-plugin[Node Resource Interface (NRI) specification] is a pluggable extension mechanism built into container runtimes like containerd and CRI-O that allows custom plugins to intercept container lifecycle events on a node. It is considered the future integration mechanism for GPUs.
+
+[WARNING]
 ====
-NVIDIA GPU Operator v26.3.x recommends using https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/cdi.html#about-the-node-resource-interface-nri-plugin[Node Resource Interface (NRI) specification] and that simplifies operations: we don't need to pass any extra envvar and it does not require changing containerd configuration. It requires containerd 2.1
+NVIDIA considers NRI as experimental
 ====
+
+If you want to try it out, please use the following manifest:
+
+[,yaml]
+----
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: gpu-operator
+  namespace: kube-system
+spec:
+  repo: https://helm.ngc.nvidia.com/nvidia
+  chart: gpu-operator
+  version: v26.3.1
+  targetNamespace: gpu-operator
+  createNamespace: true
+  valuesContent: |-
+    cdi:
+      nriPluginEnabled: true
+----
 
 [IMPORTANT]
 .Version Gate
 ====
-Containerd 2.1 is available as of September 2025 releases: v1.31.13+rke2r1, v1.32.9+rke2r1, v1.33.5+rke2r1, v1.34.1+rke2r1
+NRI requires containerd 2.1. Containerd 2.1 is available as of September 2025 releases: v1.31.13+rke2r1, v1.32.9+rke2r1, v1.33.5+rke2r1, v1.34.1+rke2r1
 ====
 
 --


### PR DESCRIPTION
Update the NVIDIA GPU Operator v26.3.x instructions:
- The two default installation manifests now configure the toolkit CONTAINERD_SOCKET env var instead of enabling the CDI NRI plugin.
- Move the NRI-based installation into a separate "v26.3.x with NRI" tab, documenting NRI as an experimental integration mechanism (with a warning) and keeping its containerd 2.1 Version Gate.

Adapted to the product-docs Antora tabs (the page had already been updated to v26.3.2). Applied to both en and zh pages; revdates bumped.

Ported from rke2-docs PR: https://github.com/rancher/rke2-docs/pull/591