### PR TITLE
[sync rke2-docs] Add August 2026 release notes

### DIFF
--- a/versions/latest/modules/en/pages/release-notes/v1.33.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.33.X.adoc
@@ -1,6 +1,6 @@
 = v1.33.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r2[v1.33.13+rke2r2], v1.33.13+rke2r2>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13313[v1.33.13]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.6-k3s1[v2.2.6-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.16.26[v0.16.26]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1], v1.33.13+rke2r1>>
 | Jun 25 2026
@@ -301,6 +318,125 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.29[Calico v3.29.3]
 | https://github.com/cilium/cilium/releases/tag/v1.17.3[v1.17.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.0[v4.2.0]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r2[v1.33.13+rke2r2]
+
+// v1.33.13+rke2r2
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.33.13.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.33.13+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10646[(#10646)]
+* Update build-images to use `PULL_CMD` instead of `docker pull` https://github.com/rancher/rke2/pull/10679[(#10679)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10666[(#10666)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10700[(#10700)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10728[(#10728)]
+* Backport chart updates to release-1.33: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10740[(#10740)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10705[(#10705)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10748[(#10748)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10758[(#10758)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10765[(#10765)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10769[(#10769)]
+* Bump Traefik v3.7.7 https://github.com/rancher/rke2/pull/10777[(#10777)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10784[(#10784)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10790[(#10790)]
+* Bump ccm - 2026 July https://github.com/rancher/rke2/pull/10798[(#10798)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10793[(#10793)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10803[(#10803)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10818[(#10818)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10827[(#10827)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10840[(#10840)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10855[(#10855)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10864[(#10864)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10846[(#10846)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10875[(#10875)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10894[(#10894)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10898[(#10898)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10904[(#10904)]
+* Update to v1.33.13-rke2r2 and Go 1.25.11 https://github.com/rancher/rke2/pull/10915[(#10915)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10911[(#10911)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10934[(#10934)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10938[(#10938)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10930[(#10930)]
+* Bump hardened-crictl to v1.33.0-build20260727 https://github.com/rancher/rke2/pull/10950[(#10950)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10961[(#10961)]
+* Bump containerd to v2.2.6-k3s1 https://github.com/rancher/rke2/pull/10966[(#10966)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10970[(#10970)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10979[(#10979)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10987[(#10987)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 [#_release_httpsgithubcomrancherrke2releasestagv13312rke2r2v13312rke2r2]
 == Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1]

--- a/versions/latest/modules/en/pages/release-notes/v1.34.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.34.X.adoc
@@ -1,6 +1,6 @@
 = v1.34.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.34.10+rke2r1[v1.34.10+rke2r1], v1.34.10+rke2r1>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v13410[v1.34.10]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.6-k3s1[v2.2.6-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.16.26[v0.16.26]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1], v1.34.9+rke2r1>>
 | Jun 25 2026
@@ -216,6 +233,124 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.30[Calico v3.30.3]
 | https://github.com/cilium/cilium/releases/tag/v1.18.1[v1.18.1]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2[v4.2.2]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.34.10+rke2r1[v1.34.10+rke2r1]
+
+// v1.34.10+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.34.10.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.34.9+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10645[(#10645)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10668[(#10668)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10699[(#10699)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10727[(#10727)]
+* Backport chart updates to release-1.34: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10739[(#10739)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10704[(#10704)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10749[(#10749)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10757[(#10757)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10764[(#10764)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10768[(#10768)]
+* Bump Traefik v3.7.7 https://github.com/rancher/rke2/pull/10776[(#10776)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10783[(#10783)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10789[(#10789)]
+* Bump ccm - 2026 July https://github.com/rancher/rke2/pull/10797[(#10797)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10792[(#10792)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10802[(#10802)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10815[(#10815)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10826[(#10826)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10839[(#10839)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10854[(#10854)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10863[(#10863)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10844[(#10844)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10874[(#10874)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10893[(#10893)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10897[(#10897)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10903[(#10903)]
+* Update to v1.34.10-rke2r1 and Go 1.25.12 https://github.com/rancher/rke2/pull/10916[(#10916)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10910[(#10910)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10933[(#10933)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10939[(#10939)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10924[(#10924)]
+* Bump hardened-crictl to v1.34.0-build20260727 https://github.com/rancher/rke2/pull/10951[(#10951)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10960[(#10960)]
+* Bump containerd to v2.2.6-k3s1 https://github.com/rancher/rke2/pull/10965[(#10965)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10978[(#10978)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10969[(#10969)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10986[(#10986)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 [#_release_httpsgithubcomrancherrke2releasestagv1348rke2r2v1348rke2r2]
 == Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1]

--- a/versions/latest/modules/en/pages/release-notes/v1.35.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.35.X.adoc
@@ -1,6 +1,6 @@
 = v1.35.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.35.7+rke2r1[v1.35.7+rke2r1], v1.35.7+rke2r1>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1357[v1.35.7]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.6-k3s1[v2.2.6-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.7[v0.17.7]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1], v1.35.6+rke2r1>>
 | Jun 25 2026
@@ -182,6 +199,124 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.31[Calico v3.31.2]
 | https://github.com/cilium/cilium/releases/tag/v1.18.4[v1.18.4]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.3[v4.2.3]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.35.7+rke2r1[v1.35.7+rke2r1]
+
+// v1.35.7+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.35.7.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.35.6+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10643[(#10643)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10669[(#10669)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10698[(#10698)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10726[(#10726)]
+* Backport chart updates to release-1.35: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10738[(#10738)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10703[(#10703)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10750[(#10750)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10756[(#10756)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10763[(#10763)]
+* Bump Traefik v3.7.7 https://github.com/rancher/rke2/pull/10773[(#10773)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10767[(#10767)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10782[(#10782)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10788[(#10788)]
+* Bump ccm - 2026 July https://github.com/rancher/rke2/pull/10796[(#10796)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10791[(#10791)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10801[(#10801)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10817[(#10817)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10825[(#10825)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10838[(#10838)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10853[(#10853)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10859[(#10859)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10843[(#10843)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10873[(#10873)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10892[(#10892)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10896[(#10896)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10902[(#10902)]
+* Update to v1.35.7-rke2r1 and Go 1.25.12 https://github.com/rancher/rke2/pull/10917[(#10917)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10909[(#10909)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10932[(#10932)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10940[(#10940)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10923[(#10923)]
+* Bump hardened-crictl to v1.35.0-build20260727 https://github.com/rancher/rke2/pull/10952[(#10952)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10959[(#10959)]
+* Bump containerd to v2.2.6-k3s1 https://github.com/rancher/rke2/pull/10964[(#10964)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10968[(#10968)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10977[(#10977)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10985[(#10985)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 [#_release_httpsgithubcomrancherrke2releasestagv1355rke2r2v1355rke2r2]
 == Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1]

--- a/versions/latest/modules/en/pages/release-notes/v1.36.X.adoc
+++ b/versions/latest/modules/en/pages/release-notes/v1.36.X.adoc
@@ -1,6 +1,6 @@
 = v1.36.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.36.3+rke2r1[v1.36.3+rke2r1], v1.36.3+rke2r1>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1363[v1.36.3]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.3.3-k3s1[v2.3.3-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.7[v0.17.7]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1], v1.36.2+rke2r1>>
 | Jun 25 2026
@@ -80,6 +97,134 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
 | https://github.com/cilium/cilium/releases/tag/v1.19.3[v1.19.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.36.3+rke2r1[v1.36.3+rke2r1]
+
+// v1.36.3+rke2r1
+
+[CAUTION]
+.Upstream `ingress-nginx` Retirement & Transition to Traefik
+====
+Because `ingress-nginx` was retired upstream as of March 2026, *Traefik is now the default for new clusters starting in v1.36* (existing clusters will keep their current ingress upon upgrade to avoid breakage). This transition brings the following structural changes:
+
+* *Airgapped Environments:* The `rke2-images-core` tarball now contains Traefik images instead of `ingress-nginx`. The standalone `rke2-images-traefik` tarball has been removed. Users who must continue using `ingress-nginx` will now need to manually provide the `rke2-images-ingress-nginx` tarball.
+* *Future Removal:* The `ingress-nginx` chart will not receive any additional updates and will be completely removed in v1.37 for community users.
+* *Prime Customers:* Please refer to the official product documentation for specific Prime considerations.
+====
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.36.3.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.36.2+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10644[(#10644)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10670[(#10670)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10697[(#10697)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10725[(#10725)]
+* Backport chart updates to release-1.36: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10741[(#10741)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10702[(#10702)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10751[(#10751)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10755[(#10755)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10762[(#10762)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10766[(#10766)]
+* Bump Traefik to v3.7.7 https://github.com/rancher/rke2/pull/10771[(#10771)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10781[(#10781)]
+* Bump CCM - 2026 July https://github.com/rancher/rke2/pull/10795[(#10795)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10787[(#10787)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10794[(#10794)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10800[(#10800)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10816[(#10816)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10824[(#10824)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10837[(#10837)]
+* Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10852[(#10852)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10857[(#10857)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10842[(#10842)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10872[(#10872)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10891[(#10891)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10895[(#10895)]
+* Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10901[(#10901)]
+* Update to v1.36.3-rke2r1 and Go 1.26.5 https://github.com/rancher/rke2/pull/10918[(#10918)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10908[(#10908)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10931[(#10931)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10941[(#10941)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10922[(#10922)]
+* Bump hardened-crictl to v1.36.0-build20260727 https://github.com/rancher/rke2/pull/10953[(#10953)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10958[(#10958)]
+* Bump containerd to v2.3.3-k3s1 https://github.com/rancher/rke2/pull/10963[(#10963)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10967[(#10967)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10976[(#10976)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10984[(#10984)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 [#_release_httpsgithubcomrancherrke2releasestagv1361rke2r2v1361rke2r2]
 == Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1]

--- a/versions/latest/modules/zh/pages/release-notes/v1.33.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.33.X.adoc
@@ -1,6 +1,6 @@
 = v1.33.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r2[v1.33.13+rke2r2], v1.33.13+rke2r2>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13313[v1.33.13]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.6-k3s1[v2.2.6-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.16.26[v0.16.26]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1], v1.33.13+rke2r1>>
 | Jun 25 2026
@@ -301,6 +318,125 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.29[Calico v3.29.3]
 | https://github.com/cilium/cilium/releases/tag/v1.17.3[v1.17.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.0[v4.2.0]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r2[v1.33.13+rke2r2]
+
+// v1.33.13+rke2r2
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.33.13.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.33.13+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10646[(#10646)]
+* Update build-images to use `PULL_CMD` instead of `docker pull` https://github.com/rancher/rke2/pull/10679[(#10679)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10666[(#10666)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10700[(#10700)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10728[(#10728)]
+* Backport chart updates to release-1.33: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10740[(#10740)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10705[(#10705)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10748[(#10748)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10758[(#10758)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10765[(#10765)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10769[(#10769)]
+* Bump Traefik v3.7.7 https://github.com/rancher/rke2/pull/10777[(#10777)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10784[(#10784)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10790[(#10790)]
+* Bump ccm - 2026 July https://github.com/rancher/rke2/pull/10798[(#10798)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10793[(#10793)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10803[(#10803)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10818[(#10818)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10827[(#10827)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10840[(#10840)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10855[(#10855)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10864[(#10864)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10846[(#10846)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10875[(#10875)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10894[(#10894)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10898[(#10898)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10904[(#10904)]
+* Update to v1.33.13-rke2r2 and Go 1.25.11 https://github.com/rancher/rke2/pull/10915[(#10915)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10911[(#10911)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10934[(#10934)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10938[(#10938)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10930[(#10930)]
+* Bump hardened-crictl to v1.33.0-build20260727 https://github.com/rancher/rke2/pull/10950[(#10950)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10961[(#10961)]
+* Bump containerd to v2.2.6-k3s1 https://github.com/rancher/rke2/pull/10966[(#10966)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10970[(#10970)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10979[(#10979)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10987[(#10987)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.33.13+rke2r1[v1.33.13+rke2r1]
 

--- a/versions/latest/modules/zh/pages/release-notes/v1.34.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.34.X.adoc
@@ -1,6 +1,6 @@
 = v1.34.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.34.10+rke2r1[v1.34.10+rke2r1], v1.34.10+rke2r1>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v13410[v1.34.10]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.6-k3s1[v2.2.6-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.16.26[v0.16.26]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1], v1.34.9+rke2r1>>
 | Jun 25 2026
@@ -216,6 +233,124 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.30[Calico v3.30.3]
 | https://github.com/cilium/cilium/releases/tag/v1.18.1[v1.18.1]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.2[v4.2.2]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.34.10+rke2r1[v1.34.10+rke2r1]
+
+// v1.34.10+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.34.10.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.34.9+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10645[(#10645)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10668[(#10668)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10699[(#10699)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10727[(#10727)]
+* Backport chart updates to release-1.34: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10739[(#10739)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10704[(#10704)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10749[(#10749)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10757[(#10757)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10764[(#10764)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10768[(#10768)]
+* Bump Traefik v3.7.7 https://github.com/rancher/rke2/pull/10776[(#10776)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10783[(#10783)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10789[(#10789)]
+* Bump ccm - 2026 July https://github.com/rancher/rke2/pull/10797[(#10797)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10792[(#10792)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10802[(#10802)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10815[(#10815)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10826[(#10826)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10839[(#10839)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10854[(#10854)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10863[(#10863)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10844[(#10844)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10874[(#10874)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10893[(#10893)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10897[(#10897)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10903[(#10903)]
+* Update to v1.34.10-rke2r1 and Go 1.25.12 https://github.com/rancher/rke2/pull/10916[(#10916)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10910[(#10910)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10933[(#10933)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10939[(#10939)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10924[(#10924)]
+* Bump hardened-crictl to v1.34.0-build20260727 https://github.com/rancher/rke2/pull/10951[(#10951)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10960[(#10960)]
+* Bump containerd to v2.2.6-k3s1 https://github.com/rancher/rke2/pull/10965[(#10965)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10978[(#10978)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10969[(#10969)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10986[(#10986)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.34.9+rke2r1[v1.34.9+rke2r1]
 

--- a/versions/latest/modules/zh/pages/release-notes/v1.35.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.35.X.adoc
@@ -1,6 +1,6 @@
 = v1.35.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.35.7+rke2r1[v1.35.7+rke2r1], v1.35.7+rke2r1>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1357[v1.35.7]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.2.6-k3s1[v2.2.6-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.7[v0.17.7]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1], v1.35.6+rke2r1>>
 | Jun 25 2026
@@ -182,6 +199,124 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.31[Calico v3.31.2]
 | https://github.com/cilium/cilium/releases/tag/v1.18.4[v1.18.4]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.3[v4.2.3]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.35.7+rke2r1[v1.35.7+rke2r1]
+
+// v1.35.7+rke2r1
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.35.7.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.35.6+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10643[(#10643)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10669[(#10669)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10698[(#10698)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10726[(#10726)]
+* Backport chart updates to release-1.35: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10738[(#10738)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10703[(#10703)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10750[(#10750)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10756[(#10756)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10763[(#10763)]
+* Bump Traefik v3.7.7 https://github.com/rancher/rke2/pull/10773[(#10773)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10767[(#10767)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10782[(#10782)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10788[(#10788)]
+* Bump ccm - 2026 July https://github.com/rancher/rke2/pull/10796[(#10796)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10791[(#10791)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10801[(#10801)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10817[(#10817)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10825[(#10825)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10838[(#10838)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10853[(#10853)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10859[(#10859)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10843[(#10843)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10873[(#10873)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10892[(#10892)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10896[(#10896)]
+** Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10902[(#10902)]
+* Update to v1.35.7-rke2r1 and Go 1.25.12 https://github.com/rancher/rke2/pull/10917[(#10917)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10909[(#10909)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10932[(#10932)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10940[(#10940)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10923[(#10923)]
+* Bump hardened-crictl to v1.35.0-build20260727 https://github.com/rancher/rke2/pull/10952[(#10952)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10959[(#10959)]
+* Bump containerd to v2.2.6-k3s1 https://github.com/rancher/rke2/pull/10964[(#10964)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10968[(#10968)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10977[(#10977)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10985[(#10985)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.35.6+rke2r1[v1.35.6+rke2r1]
 

--- a/versions/latest/modules/zh/pages/release-notes/v1.36.X.adoc
+++ b/versions/latest/modules/zh/pages/release-notes/v1.36.X.adoc
@@ -1,6 +1,6 @@
 = v1.36.X
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-03
+:revdate: 2026-08-24
 :page-revdate: {revdate}
 
 [CAUTION]
@@ -11,6 +11,23 @@ Before upgrading from earlier releases, be sure to read the Kubernetes https://g
 
 |===
 | Version | Release date | Kubernetes | Etcd | Containerd | Runc | Metrics-server | CoreDNS | Ingress-Nginx | Helm-controller | Traefik | Canal (Default) | Calico | Cilium | Multus
+
+| <<Release https://github.com/rancher/rke2/releases/tag/v1.36.3+rke2r1[v1.36.3+rke2r1], v1.36.3+rke2r1>>
+| Aug 04 2026
+| https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1363[v1.36.3]
+| https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1[v3.6.14-k3s1]
+| https://github.com/k3s-io/containerd/releases/tag/v2.3.3-k3s1[v2.3.3-k3s1]
+| https://github.com/opencontainers/runc/releases/tag/v1.4.3[v1.4.3]
+| https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0[v0.9.0]
+| https://github.com/coredns/coredns/releases/tag/v1.14.6[v1.14.6]
+| https://github.com/rancher/ingress-nginx/releases/tag/v1.15.1-prime9[v1.15.1-prime9]
+| https://github.com/k3s-io/helm-controller/releases/tag/v0.17.7[v0.17.7]
+| https://github.com/traefik/traefik/releases/tag/v3.7.8[v3.7.8]
+| https://github.com/flannel-io/flannel/releases/tag/v0.28.8[Flannel v0.28.8] +
+https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.1]
+| https://docs.tigera.io/calico/latest/release-notes/#v3.32[v3.32.1]
+| https://github.com/cilium/cilium/releases/tag/v1.19.6[v1.19.6]
+| https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.3.0[v4.3.0]
 
 | <<Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1], v1.36.2+rke2r1>>
 | Jun 25 2026
@@ -80,6 +97,134 @@ https://docs.tigera.io/calico/latest/release-notes/#v3.32[Calico v3.32.0]
 | https://github.com/cilium/cilium/releases/tag/v1.19.3[v1.19.3]
 | https://github.com/k8snetworkplumbingwg/multus-cni/releases/tag/v4.2.4[v4.2.4]
 |===
+
+== Release https://github.com/rancher/rke2/releases/tag/v1.36.3+rke2r1[v1.36.3+rke2r1]
+
+// v1.36.3+rke2r1
+
+[CAUTION]
+.Upstream `ingress-nginx` Retirement & Transition to Traefik
+====
+Because `ingress-nginx` was retired upstream as of March 2026, *Traefik is now the default for new clusters starting in v1.36* (existing clusters will keep their current ingress upon upgrade to avoid breakage). This transition brings the following structural changes:
+
+* *Airgapped Environments:* The `rke2-images-core` tarball now contains Traefik images instead of `ingress-nginx`. The standalone `rke2-images-traefik` tarball has been removed. Users who must continue using `ingress-nginx` will now need to manually provide the `rke2-images-ingress-nginx` tarball.
+* *Future Removal:* The `ingress-nginx` chart will not receive any additional updates and will be completely removed in v1.37 for community users.
+* *Prime Customers:* Please refer to the official product documentation for specific Prime considerations.
+====
+
+[CAUTION]
+====
+This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details
+====
+
+This release updates Kubernetes to v1.36.3.
+
+*Important Note*
+
+If your server (control-plane) nodes were not started with the `--token` CLI flag or config file key, a randomized token was generated during initial cluster startup. This key is used both for joining new nodes to the cluster, and for encrypting cluster bootstrap data within the datastore. Ensure that you retain a copy of this token, as is required when restoring from backup.
+
+You may retrieve the token value from any server already joined to the cluster:
+
+[,bash]
+----
+cat /var/lib/rancher/rke2/server/token
+----
+
+=== Changes since v1.36.2+rke2r1:
+
+* Bump HCP 0.2.12 https://github.com/rancher/rke2/pull/10644[(#10644)]
+* Charts: Bump Harvester CSI driver 0.1.30 https://github.com/rancher/rke2/pull/10670[(#10670)]
+* Update ingress-nginx to chart 4.15.102 / image v1.15.1-prime5 https://github.com/rancher/rke2/pull/10697[(#10697)]
+* Bump hardened runtime images for Go/x-net CVE fixes https://github.com/rancher/rke2/pull/10725[(#10725)]
+* Backport chart updates to release-1.36: canal, calico, cilium, multus… https://github.com/rancher/rke2/pull/10741[(#10741)]
+* Bump HCP to 0.2.14 https://github.com/rancher/rke2/pull/10702[(#10702)]
+* Bump klipper-helm to v0.12.1-build20260709 https://github.com/rancher/rke2/pull/10751[(#10751)]
+* Bump snapshot-controller image tag to v8.6.0-build20260708 https://github.com/rancher/rke2/pull/10755[(#10755)]
+* Update to coredns chart 1.46.004 and metrics-server chart 3.13.102 https://github.com/rancher/rke2/pull/10762[(#10762)]
+* Update ingress-nginx to chart 4.15.103 / image v1.15.1-prime6 https://github.com/rancher/rke2/pull/10766[(#10766)]
+* Bump Traefik to v3.7.7 https://github.com/rancher/rke2/pull/10771[(#10771)]
+* Update Multus chart to v4.3.004 https://github.com/rancher/rke2/pull/10781[(#10781)]
+* Bump CCM - 2026 July https://github.com/rancher/rke2/pull/10795[(#10795)]
+* Bump etcd to 3.6.12-k3s1-build20260708 https://github.com/rancher/rke2/pull/10787[(#10787)]
+* Add PRIME versions of the vsphere images https://github.com/rancher/rke2/pull/10794[(#10794)]
+* Bump k3s for 2026-07 https://github.com/rancher/rke2/pull/10800[(#10800)]
+* Bump ingress-nginx version to prime7 https://github.com/rancher/rke2/pull/10816[(#10816)]
+* Update Canal chart to v3.32.1-build2026070901 https://github.com/rancher/rke2/pull/10824[(#10824)]
+* Update to coredns chart 1.46.1 and metrics-server chart 3.13.1 https://github.com/rancher/rke2/pull/10837[(#10837)]
+* Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10852[(#10852)]
+* Bump Traefik to v3.7.8 https://github.com/rancher/rke2/pull/10857[(#10857)]
+* Bump k3s again for 2026-07 https://github.com/rancher/rke2/pull/10842[(#10842)]
+* Chore: Update rke2-ingress-nginx version in charts/chart_versions.yaml https://github.com/rancher/rke2/pull/10872[(#10872)]
+* Bump helm-controller and klipper-helm for --force-conflicts support https://github.com/rancher/rke2/pull/10891[(#10891)]
+* Don't clean up data dirs still referenced by containers https://github.com/rancher/rke2/pull/10895[(#10895)]
+* Update CNIs for 2026-07 Release Cycle https://github.com/rancher/rke2/pull/10901[(#10901)]
+* Update to v1.36.3-rke2r1 and Go 1.26.5 https://github.com/rancher/rke2/pull/10918[(#10918)]
+* Bump hardened images to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf) https://github.com/rancher/rke2/pull/10908[(#10908)]
+* Update vsphere-csi chart (#10912) https://github.com/rancher/rke2/pull/10931[(#10931)]
+* Fix package-windows-images platform matching https://github.com/rancher/rke2/pull/10941[(#10941)]
+* Validate-charts: validate vsphere prime (hardened) images https://github.com/rancher/rke2/pull/10922[(#10922)]
+* Bump hardened-crictl to v1.36.0-build20260727 https://github.com/rancher/rke2/pull/10953[(#10953)]
+* Bump helm-controller and klipper-helm https://github.com/rancher/rke2/pull/10958[(#10958)]
+* Bump containerd to v2.3.3-k3s1 https://github.com/rancher/rke2/pull/10963[(#10963)]
+* Bump ingress-nginx chart and version https://github.com/rancher/rke2/pull/10967[(#10967)]
+* Bump vSphere CSI chart to 3.7.2-rancher500 and hardened-csi-provisioner to v4.0.1-build20260730 https://github.com/rancher/rke2/pull/10976[(#10976)]
+* Update rancher-vsphere-csi to 3.7.2-rancher600 and align hardened CSI images https://github.com/rancher/rke2/pull/10984[(#10984)]
+
+=== Charts Versions
+
+|===
+| Component | Version
+
+| rke2-cilium
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-cilium/rke2-cilium-1.19.601.tgz[1.19.601]
+
+| rke2-canal
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-canal/rke2-canal-v3.32.1-build2026072200.tgz[v3.32.1-build2026072200]
+
+| rke2-calico
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-v3.32.100.tgz[v3.32.100]
+
+| rke2-calico-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-calico/rke2-calico-crd-v3.32.100.tgz[v3.32.100]
+
+| rke2-coredns
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-coredns/rke2-coredns-1.46.201.tgz[1.46.201]
+
+| rke2-ingress-nginx
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-ingress-nginx/rke2-ingress-nginx-4.15.107.tgz[4.15.107]
+
+| rke2-metrics-server
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-metrics-server/rke2-metrics-server-3.13.105.tgz[3.13.105]
+
+| rke2-multus
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-multus/rke2-multus-v4.3.008.tgz[v4.3.008]
+
+| rancher-vsphere-csi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-csi/rancher-vsphere-csi-3.7.2-rancher700.tgz[3.7.2-rancher700]
+
+| rancher-vsphere-cpi
+| https://github.com/rancher/rke2-charts/raw/main/assets/rancher-vsphere-cpi/rancher-vsphere-cpi-1.15.300.tgz[1.15.300]
+
+| harvester-cloud-provider
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1400.tgz[0.2.1400]
+
+| harvester-csi-driver
+| https://github.com/rancher/rke2-charts/raw/main/assets/harvester-cloud-provider/harvester-csi-driver-0.1.3000.tgz[0.1.3000]
+
+| rke2-snapshot-controller
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-4.2.008.tgz[4.2.008]
+
+| rke2-snapshot-controller-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-snapshot-controller/rke2-snapshot-controller-crd-4.2.008.tgz[4.2.008]
+
+| rke2-traefik
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-40.1.009.tgz[40.1.009]
+
+| rke2-traefik-crd
+| https://github.com/rancher/rke2-charts/raw/main/assets/rke2-traefik/rke2-traefik-crd-40.1.009.tgz[40.1.009]
+|===
+
+'''
 
 == Release https://github.com/rancher/rke2/releases/tag/v1.36.2+rke2r1[v1.36.2+rke2r1]
 


### PR DESCRIPTION
Ports the August 2026 release-note update from rke2-docs to the AsciiDoc release-notes pages, for both the en and zh trees.

Source: rancher/rke2-docs commit b901ed91, PR rancher/rke2-docs#623
        ("update release-notes/v1.XX.X.md August 2026")

New releases documented (all dated Aug 04 2026):

  * v1.33.13+rke2r2 - Kubernetes v1.33.13, containerd v2.2.6-k3s1, helm-controller v0.16.26
  * v1.34.10+rke2r1 - Kubernetes v1.34.10, containerd v2.2.6-k3s1, helm-controller v0.16.26
  * v1.35.7+rke2r1  - Kubernetes v1.35.7,  containerd v2.2.6-k3s1, helm-controller v0.17.7
  * v1.36.3+rke2r1  - Kubernetes v1.36.3,  containerd v2.3.3-k3s1, helm-controller v0.17.7

Shared across all four: etcd v3.6.14-k3s1, runc v1.4.3, metrics-server v0.9.0, CoreDNS v1.14.6, Ingress-Nginx v1.15.1-prime9, Traefik v3.7.8, Canal (Flannel v0.28.8 + Calico v3.32.1), Calico v3.32.1, Cilium v1.19.6, Multus v4.3.0.

For each page: a new row at the top of the summary table, a new release section (changelog + Charts Versions table) above the previous release, and a bumped revdate. No new column was added.

Notes on deviations from the upstream source:

  * The Ingress-Nginx value is Prime-specific and does not exist upstream. It was read from the Prime artifacts host: all four releases bundle nginx-ingress-controller:v1.15.1-prime9 (the community build ships v1.14.5-hardened2, which is not the right value for these docs).

  * The rke2-multus chart tarball URL is written as assets/rke2-multus/rke2-multus-v4.3.008.tgz. The upstream generator emits assets/rke2-traefik/..., which 404s; rke2-multus charts live under assets/rke2-multus/.

  * v1.36.3 carries the upstream ingress-nginx retirement notice verbatim, including its pointer to "the official product documentation" for Prime considerations. That sentence is self-referential in this repo and may be worth rewording.